### PR TITLE
[FIX] not include Sidekiq::Worker into Job class with ActiveJob.

### DIFF
--- a/app/jobs/periodic_serverspec_job.rb
+++ b/app/jobs/periodic_serverspec_job.rb
@@ -8,7 +8,6 @@
 
 class PeriodicServerspecJob < ActiveJob::Base
   queue_as :default
-  include Sidekiq::Worker
 
   def perform(physical_id, infra_id, user_id)
     schedule = ServerspecSchedule.find_by(physical_id: physical_id)

--- a/app/jobs/periodic_yum_job.rb
+++ b/app/jobs/periodic_yum_job.rb
@@ -1,6 +1,5 @@
 class PeriodicYumJob < ActiveJob::Base
   queue_as :default
-  include Sidekiq::Worker
 
   def perform(physical_id, infra, user_id)
     schedule = YumSchedule.find_by(physical_id: physical_id)

--- a/app/jobs/serverspec_job.rb
+++ b/app/jobs/serverspec_job.rb
@@ -8,8 +8,6 @@
 
 class ServerspecJob < ActiveJob::Base
   queue_as :default
-  include Sidekiq::Worker
-  sidekiq_options retry: false
 
   # Serverspec を実行し、結果をインフラログに書き出す。
   # また、Resource の Serverspec IDs を更新する。

--- a/app/jobs/yum_job.rb
+++ b/app/jobs/yum_job.rb
@@ -1,6 +1,5 @@
 class YumJob < ActiveJob::Base
   queue_as :default
-  include Sidekiq::Worker
 
   def perform(physical_id, infra, user_id, cook=false, security=true, exec=false)
     ws = WSConnector.new('notifications', User.find(user_id).ws_key)


### PR DESCRIPTION
最新の`Sidekiq`で動くように対応しました。
私は`ActiveJob`周りに明るくないので、問題があったら教えて下さい

Ref
----

- https://github.com/mperham/sidekiq/issues/2424
- https://travis-ci.org/skyarch-networks/skyhopper/jobs/71870513