### PR TITLE
Check EIP limit when deploy wizard.

### DIFF
--- a/app/assets/javascripts/app_settings.js
+++ b/app/assets/javascripts/app_settings.js
@@ -27,7 +27,7 @@
       data: {
         settings: JSON.stringify(settings)
       },
-    }).fail(modal_for_ajax_std_error);
+    }).fail(modal_for_ajax_std_error());
   };
 
   var chef_create = function () {
@@ -41,7 +41,7 @@
       },
       dataType: "json",
 
-    }).fail(modal_for_ajax_std_error);
+    }).fail(modal_for_ajax_std_error());
   };
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,7 @@ en:
       aws_region:        'Regions of AWS available for SkyHopper System'
       aws_keypair:       'SSH key used for SkyHopper System (Registered KeyPair from EC2 console that is linked with API key above)'
       zabbix_updated:    'Zabbix Setting was successfully updated.'
+      eip_limit_error:   'Cannot allocate EIP. Please check the limit of EIP.'
     title:
       show:   'Welcome to SkyHopper!'
       setup:  'Setup'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -80,6 +80,7 @@ ja:
       aws_region:        'SkyHopper のシステムが使用する AWS のリージョン'
       aws_keypair:       'SkyHopper のシステムが使用する SSH鍵（上記の APIキー に紐付けられた EC2 のコンソールから登録した鍵ペアを指定）'
       zabbix_updated:    'Zabbix の設定は正常に更新されました。'
+      eip_limit_error:   'EIP を確保することが出来ません。EIP の個数制限を確認して下さい。'
     title:
       show:   'SkyHopper へようこそ'
       setup:  'SkyHopper のセットアップ'

--- a/spec/controllers/app_settings_controller_spec.rb
+++ b/spec/controllers/app_settings_controller_spec.rb
@@ -38,7 +38,10 @@ describe AppSettingsController, :type => :controller do
     let(:ec2key){create(:ec2_private_key)}
     let(:settings_with_ec2_key_id){settings.merge(keypair_name: ec2key.name, keypair_value: ec2key.value)}
 
-    before{allow(Thread).to receive(:new_with_db)}
+    before do
+      allow(Thread).to receive(:new_with_db)
+      allow_any_instance_of(AppSettingsController).to receive(:check_eip_limit!)
+    end
 
     context 'when valid settings' do
       before do
@@ -114,6 +117,48 @@ describe AppSettingsController, :type => :controller do
         AppSetting.clear_cache
         expect(AppSetting.get.zabbix_user).not_to eq zabbix_user
         expect(AppSetting.get.zabbix_pass).not_to eq zabbix_pass
+      end
+    end
+  end
+
+  describe '#check_eip_limit!' do
+    controller AppSettingsController do
+      def authorize(*args)end #XXX: pundit hack
+      def test
+        check_eip_limit!('ap-northeast-1', 'ACCESS_KEY', 'SECRET')
+        render text: 'success'
+      rescue ::AppSettingsController::EIPLimitError => ex
+        render text: 'failure', status: 400
+      end
+    end
+    before{routes.draw{resources(:app_settings){collection{get :test}}}}
+    let(:req){get :test}
+
+    let(:eip_n){2}
+
+    before do
+      res = double('describe_account_attributes response')
+      allow(res).to receive_message_chain(:account_attributes, :find, :attribute_values, :first, :attribute_value).and_return('5')
+      allow_any_instance_of(Aws::EC2::Client).to receive(:describe_account_attributes).and_return(res)
+      allow_any_instance_of(Aws::EC2::Client).to receive_message_chain(:describe_addresses, :addresses).and_return(Array.new(eip_n))
+      req
+    end
+
+    context 'when can allocate EIP' do
+      let(:eip_n){2}
+      should_be_success
+
+      it 'should be set body' do
+        expect(response.body).to eq 'success'
+      end
+    end
+
+    context 'when cannot allocate EIP' do
+      let(:eip_n){4}
+      should_be_failure
+
+      it 'should be set body' do
+        expect(response.body).to eq 'failure'
       end
     end
   end


### PR DESCRIPTION
EIP の個数制限を Deploy Wizard で最初にデータを送った時に検証し、もし EIP が足りなければエラーを表示するようにしました。