### PR TITLE
[Hotfix] remove backend pagination diverto to vue.js

### DIFF
--- a/app/controllers/cf_templates_controller.rb
+++ b/app/controllers/cf_templates_controller.rb
@@ -29,7 +29,7 @@ class CfTemplatesController < ApplicationController
 
     respond_to do |format|
       format.json { @global_jsons = @global_jsons }
-      format.html { @global_jsons = @global_jsons.page(page).per(10) }
+      format.html { @global_jsons = @global_jsons.page(page)}
     end
   end
 

--- a/spec/controllers/cf_templates_controller_spec.rb
+++ b/spec/controllers/cf_templates_controller_spec.rb
@@ -29,7 +29,7 @@ describe CfTemplatesController, :type => :controller do
     end
 
     context 'format html' do
-      let(:global_jsons){ klass.global.page(1).per(10) }
+      let(:global_jsons){ klass.global.page(1) }
 
       it 'should assign @global_jsons' do
         get :index, format: 'html'


### PR DESCRIPTION
Please merge this to next version. A hotfix for the pagination in cloudformation index page.

