### PR TITLE
Use EIP as FQDN

### DIFF
--- a/app/models/ec2_instance.rb
+++ b/app/models/ec2_instance.rb
@@ -94,6 +94,7 @@ class EC2Instance < SimpleDelegator
 
   def fqdn
     return self.public_dns_name.presence ||
+           self.elastic_ip.presence ||
            self.private_dns_name
   end
 


### PR DESCRIPTION
- not have public_dns
- have elastic_ip
- have private_dns

There's an EC2 instance like the above in yunoki san's AWS 

Before this patch, When we call `fqdn` method for EC2 instance like the above, returns private_dns.
However, we want an elastic_ip.

