### PR TITLE
Prevent redirect loop when Sprockets::FileNotFound

### DIFF
--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -65,6 +65,8 @@ module Concerns::ErrorHandler
   def rescue_exception(ex)
     Rails.logger.error(ex.inspect + " from " + ex.backtrace.first)
     Rails.logger.debug(ex.backtrace.join("\n"))
+    raise ex if ex.is_a? Sprockets::FileNotFound # prevent redirect loop
+
     if ajax?
       render json: {error: ex.format_error}, status: ex.status_code and return
     else


### PR DESCRIPTION
see: https://skyarch.backlog.jp/view/NC-555

We often encounter redirect loop after `git pull`.
In many case, cause is forgetting `bower intall`, `npm install`, `gulp ts`, ...
but this is confusing. so, prevent redirect-loop and show better_errors console.



@Joeper214  please review and merge :bow: