### PR TITLE
downgrade browserify rails becuase causing problems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'libv8'
 gem 'jbuilder'
 
 # Modularize javascript code in application
-gem 'browserify-rails'
+gem 'browserify-rails', '~> 1.5.0'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,10 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    browserify-rails (2.0.1)
+    browserify-rails (1.5.0)
       railties (>= 4.0.0, < 5.0)
       sprockets (> 3.0.2)
+      tilt (>= 1.1, < 3)
     buff-config (1.0.1)
       buff-extensions (~> 1.0)
       varia_model (~> 0.4)
@@ -510,7 +511,7 @@ DEPENDENCIES
   aws-sdk-v1
   better_errors
   binding_of_caller
-  browserify-rails
+  browserify-rails (~> 1.5.0)
   bullet
   chef (~> 12)
   coffee-rails


### PR DESCRIPTION
### Browserify is on version 2.0.1
Still unstable version. I'll update this after a few months.


I'll merge this once done.