### PR TITLE
Nginx serve assets

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,17 +18,6 @@
  *= require font-awesome
  */
 
-@font-face {
-  font-family: 'glyphicon localized';
-
-  src: url('/assets/glyphicons-halflings-regular.eot');
-  src: url('/assets/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('/assets/glyphicons-halflings-regular.woff') format('woff'), url('/assets/glyphicons-halflings-regular.ttf') format('truetype'), url('/assets/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
-}
-
-.glyphicon {
-  font-family: 'glyphicon localized' !important;
-}
-
 .modal-header {
   border-top-left-radius: 6px;
   border-top-right-radius: 6px;
@@ -48,7 +37,7 @@
 
 @font-face {
   font-family: 'NotoSans';
-  src: url('/assets/NotoSansJP-Regular.otf') format('opentype');
+  src: url('/fonts/NotoSansJP-Regular.otf') format('opentype');
 }
 
 body {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,8 +23,9 @@ SkyHopper::Application.configure do
   config.serve_static_files = false
 
   # Compress JavaScripts and CSS.
+  config.assets.compress = true
   config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = true
@@ -59,7 +60,8 @@ SkyHopper::Application.configure do
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-  # config.assets.precompile += %w( search.js )
+  config.assets.precompile += %w( * )
+  config.assets.initialize_on_precompile = true
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/doc/installation/skyhopper.md
+++ b/doc/installation/skyhopper.md
@@ -60,6 +60,10 @@ server {
         listen 80;
         server_name skyhopper.local; #環境に合わせて設定
 
+        location ~ ^/(assets|fonts) {
+          root /home/ec2-user/skyhopper/public; # もしskyhopperをcloneした場所が異なる場合修正
+        }
+
         location / {
             proxy_set_header    X-Real-IP   \$remote_addr;
             proxy_set_header    Host    \$http_host;

--- a/public/fonts/glyphicons-halflings-regular.eot
+++ b/public/fonts/glyphicons-halflings-regular.eot
@@ -1,0 +1,1 @@
+../../vendor/bower_components/bootstrap/fonts/glyphicons-halflings-regular.eot

--- a/public/fonts/glyphicons-halflings-regular.svg
+++ b/public/fonts/glyphicons-halflings-regular.svg
@@ -1,0 +1,1 @@
+../../vendor/bower_components/bootstrap/fonts/glyphicons-halflings-regular.svg

--- a/public/fonts/glyphicons-halflings-regular.ttf
+++ b/public/fonts/glyphicons-halflings-regular.ttf
@@ -1,0 +1,1 @@
+../../vendor/bower_components/bootstrap/fonts/glyphicons-halflings-regular.ttf

--- a/public/fonts/glyphicons-halflings-regular.woff
+++ b/public/fonts/glyphicons-halflings-regular.woff
@@ -1,0 +1,1 @@
+../../vendor/bower_components/bootstrap/fonts/glyphicons-halflings-regular.woff

--- a/public/fonts/glyphicons-halflings-regular.woff2
+++ b/public/fonts/glyphicons-halflings-regular.woff2
@@ -1,0 +1,1 @@
+../../vendor/bower_components/bootstrap/fonts/glyphicons-halflings-regular.woff2

--- a/vendor/assets/fonts/glyphicons-halflings-regular.eot
+++ b/vendor/assets/fonts/glyphicons-halflings-regular.eot
@@ -1,1 +1,0 @@
-../../bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.eot

--- a/vendor/assets/fonts/glyphicons-halflings-regular.svg
+++ b/vendor/assets/fonts/glyphicons-halflings-regular.svg
@@ -1,1 +1,0 @@
-../../bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.svg

--- a/vendor/assets/fonts/glyphicons-halflings-regular.ttf
+++ b/vendor/assets/fonts/glyphicons-halflings-regular.ttf
@@ -1,1 +1,0 @@
-../../bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf

--- a/vendor/assets/fonts/glyphicons-halflings-regular.woff
+++ b/vendor/assets/fonts/glyphicons-halflings-regular.woff
@@ -1,1 +1,0 @@
-../../bower_components/bootstrap/dist/fonts/glyphicons-halflings-regular.woff


### PR DESCRIPTION
NC-585


- [x] precompile config
- [x] fonts path
- [x] nginx setting in document

Update process
------

Add the following code into server block of your nginx.conf .

```nginx
location ~ ^/(assets|fonts) {
  root /home/pocke/ghq/github.com/skyarch-networks/skyhopper/public;
}
```

and restart nginx(e.g. `systemctl nginx restart`)

and restart SkyHopper

```sh
./scripts/skyhopper_daemon.sh stop
./scripts/skyhopper_daemon.sh start
```