### PR TITLE
Remove unnecessary require

### DIFF
--- a/app/assets/javascripts/libraries.js
+++ b/app/assets/javascripts/libraries.js
@@ -26,4 +26,3 @@
 //= require selectize
 //= require fullcalendar
 //= require lang-all
-//= require xray


### PR DESCRIPTION
An error occurs because xray gem isn't loaded in production.

Xray insert itself into views automatically.
So `//= require xray` is not necessary.