### PR TITLE
Remove only non history cf-template when rake db:seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,6 +78,6 @@ template_paths.each do |path|
   parsed = JSON.parse(value)
   detail = parsed['Description']
 
-  CfTemplate.delete_all(name: name)
+  CfTemplate.where(name: name, infrastructure_id: nil).delete_all
   CfTemplate.create(name: name, detail: detail, value: value)
 end


### PR DESCRIPTION
Ref: https://skyarch.backlog.jp/view/NC-590

When we re-run `rake db:seed`, SkyHopper delete cf-template history.
I fixed it.

@Joeper214 please review and merge it :bow:

