### PR TITLE
Refactor infra js

### DIFF
--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -55,26 +55,7 @@
   var alert_and_show_infra = helpers.alert_and_show_infra;
 
 
-  Vue.component("stack-events-table", {
-    props: { events: Array, },
-    template: '#stack-events-table-template',
-    methods: {
-      event_tr_class: function (status) {
-        if      (status === "CREATE_COMPLETE")    { return "success"; }
-        else if (status.indexOf("FAILED") !== -1) { return "danger"; }
-        else if (status.indexOf("DELETE") !== -1) { return "warning"; }
-        return '';
-      },
-      toLocaleString: toLocaleString,
-    },
-    created: function () {
-      var self = this;
-      console.log(self);
-      this.$watch('events', function () {
-        $(self.$el).hide().fadeIn(800);
-      });
-    },
-  });
+  Vue.component('stack-events-table', require('infrastructures/stack-events-table.js'));
 
   Vue.component("add-modify-tabpane", {
     props: {

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -2393,7 +2393,7 @@
 
   var SHOW_INFRA_ID = '#infra-show';
 
-  var show_infra = function (infra_id) {
+  var show_infra = function (infra_id, current_tab) {
     current_infra = new Infrastructure(infra_id);
 
     var l = new Loader();
@@ -2410,38 +2410,12 @@
         CFTemplate,
         alert_danger,
         stack_in_progress,
-        ''
+        current_tab
       );
       l.$destroy();
       app.$mount(SHOW_INFRA_ID);
     });
   };
-
-  var show_sched = function (infra_id) {
-    current_infra = new Infrastructure(infra_id);
-
-    var l = new Loader();
-    l.text = "Loading...";
-    l.$mount(SHOW_INFRA_ID);
-    if (app) {
-      app.$destroy();
-    }
-    current_infra.show().done(function (stack) {
-      app = newVM(
-        stack,
-        Resource,
-        EC2Instance,
-        current_infra,
-        CFTemplate,
-        alert_danger,
-        stack_in_progress,
-        'show_sched'
-      );
-      l.$destroy();
-      app.$mount(SHOW_INFRA_ID);
-    });
-  };
-
 
   var detach = function (infra_id) {
     modal.Confirm(t('infrastructures.infrastructure'), t('infrastructures.msg.detach_stack_confirm'), 'danger').done(function () {
@@ -2562,7 +2536,7 @@
     $(this).closest('tbody').children('tr').removeClass('info');
     $(this).closest('tr').addClass('info');
     var infra_id = $(this).attr('infrastructure-id');
-    show_infra(infra_id);
+    show_infra(infra_id, '');
   });
 
   $(document).on('click', '.operation-sched', function (e) {
@@ -2570,7 +2544,7 @@
     $(this).closest('tbody').children('tr').removeClass('info');
     $(this).closest('tr').addClass('info');
     var infra_id = $(this).attr('infrastructure-id');
-    show_sched(infra_id);
+    show_infra(infra_id, 'show_sched');
   });
 
   $(document).on('click', '.detach-infra', function (e) {

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -47,48 +47,13 @@
   require('brace/theme/github');
   Vue.use(vace, false, 'json', '25');
 
-  // Vueに登録したfilterを、外から見る方法ってないのかな。
-  var jsonParseErr = function (str) {
-    if (_.trim(str) === '') {
-      return 'JSON String is empty. Please input JSON.';
-    }
-    try {
-      JSON.parse(str);
-    } catch (ex) {
-      return ex;
-    }
-  };
+  var helpers = require('infrastructures/helper.js');
+  var jsonParseErr         = jsonParseErr;
+  var toLocaleString       = toLocaleString;
+  var alert_success        = alert_success;
+  var alert_danger         = alert_danger;
+  var alert_and_show_infra = alert_and_show_infra;
 
-  var toLocaleString = function (datetext) {
-    var date = new Date(datetext);
-    return date.toLocaleString();
-  };
-
-
-  // Utilities
-  var alert_success = function (callback) {
-    return function (msg) {
-      var dfd = modal.Alert(t('infrastructures.infrastructure'), msg);
-      if (callback) {
-        dfd.done(callback);
-      }
-    };
-  };
-
-  var alert_danger = function (callback) {
-    return function (msg) {
-      if (!jsonParseErr(msg) && JSON.parse(msg).error) {
-        modal.AlertForAjaxStdError(callback)(msg);
-      } else {
-        var dfd = modal.Alert(t('infrastructures.infrastructure'), msg, 'danger');
-        if (callback) { dfd.done(callback); }
-      }
-    };
-  };
-
-  var alert_and_show_infra = alert_danger(function () {
-    show_infra(current_infra.id);
-  });
 
   Vue.component("stack-events-table", {
     props: { events: Array, },

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -56,43 +56,7 @@
 
 
   Vue.component('stack-events-table', require('infrastructures/stack-events-table.js'));
-
-  Vue.component("add-modify-tabpane", {
-    props: {
-      templates: {
-        type: Object,
-        required: true,
-      },
-      result: {
-        type: Object,
-        required: true,
-      },
-    },
-    data: function(){
-      return{selected_cft_id: null,};},
-    template: '#add-modify-tabpane-template',
-    methods: {
-      select_cft: function () {
-        var self = this;
-        var cft = _.find(self.templates.histories.concat(self.templates.globals), function (c) {
-          return c.id === self.selected_cft_id;
-        });
-        self.result.name   = cft.name;
-        self.result.detail = cft.detail;
-        self.result.value  = cft.value;
-
-      },
-      submit: function () {
-        if (this.jsonParseErr) {return;}
-        app.show_tabpane('insert-cf-params');
-        app.loading = true;
-      },
-    },
-    computed: {
-      jsonParseErr: function () { return jsonParseErr(this.result.value); },
-    },
-
-  });
+  Vue.component('add-modify-tabpane', require('infrastructures/add-modify-tabpane.js'));
 
 
   Vue.component("insert-cf-params", {

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -2485,45 +2485,33 @@
   });
 
 
-  var stack_in_progress = function (infra) {
-    infra.stack_events().done(function (res) {
-      app.$data.current_infra.events = res.stack_events;
-
-      if (res.stack_status.type === 'IN_PROGRESS') {
-        setTimeout(function () {
-          stack_in_progress(infra);
-        }, 15000);
-      } else {
-        show_infra(infra.id);
-      }
-    });
-  };
-
   var SHOW_INFRA_ID = '#infra-show';
 
-  var show_infra = function (infra_id, current_tab) {
-    var infra = new Infrastructure(infra_id);
+  var show_infra = (function () {
+    var app;
+    return function (infra_id, current_tab) {
+      var infra = new Infrastructure(infra_id);
 
-    var l = new Loader();
-    l.text = "Loading...";
-    l.$mount(SHOW_INFRA_ID);
-    if (app) {
-      app.$destroy();
-    }
-    infra.show().done(function (stack) {
-      app = newVM(stack,
-        Resource,
-        EC2Instance,
-        infra,
-        CFTemplate,
-        alert_danger,
-        stack_in_progress,
-        current_tab
-      );
-      l.$destroy();
-      app.$mount(SHOW_INFRA_ID);
-    });
-  };
+      var l = new Loader();
+      l.text = "Loading...";
+      l.$mount(SHOW_INFRA_ID);
+      if (app) {
+        app.$destroy();
+      }
+      infra.show().done(function (stack) {
+        app = newVM(stack,
+          Resource,
+          EC2Instance,
+          infra,
+          CFTemplate,
+          alert_danger,
+          current_tab
+        );
+        l.$destroy();
+        app.$mount(SHOW_INFRA_ID);
+      });
+    };
+  })();
 
   var detach = function (infra_id) {
     modal.Confirm(t('infrastructures.infrastructure'), t('infrastructures.msg.detach_stack_confirm'), 'danger').done(function () {

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -22,7 +22,6 @@
   var wrap = require('./modules/wrap');
   var listen = require('./modules/listen');
   //var infraindex = require('./modules/loadindex');
-  var newVM = require('./modules/newVM');
   var queryString = require('query-string').parse(location.search);
   //browserify modules for Vue directives
   var CFTemplate     = require('models/cf_template').default;
@@ -2485,33 +2484,9 @@
   });
 
 
-  var SHOW_INFRA_ID = '#infra-show';
-
-  var show_infra = (function () {
-    var app;
-    return function (infra_id, current_tab) {
-      var infra = new Infrastructure(infra_id);
-
-      var l = new Loader();
-      l.text = "Loading...";
-      l.$mount(SHOW_INFRA_ID);
-      if (app) {
-        app.$destroy();
-      }
-      infra.show().done(function (stack) {
-        app = newVM(stack,
-          Resource,
-          EC2Instance,
-          infra,
-          CFTemplate,
-          alert_danger,
-          current_tab
-        );
-        l.$destroy();
-        app.$mount(SHOW_INFRA_ID);
-      });
-    };
-  })();
+  var show = require('infrastructures/show_infra.js');
+  var show_infra = show.show_infra;
+  var SHOW_INFRA_ID = show.SHOW_INFRA_ID;
 
   var detach = function (infra_id) {
     modal.Confirm(t('infrastructures.infrastructure'), t('infrastructures.msg.detach_stack_confirm'), 'danger').done(function () {

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -12,8 +12,6 @@
 
   google.load('visualization',   '1.0',   {'packages':['corechart']});
 
-  var app;
-
   ZeroClipboard.config({swfPath: '/assets/ZeroClipboard.swf'});
 
 // ================================================================
@@ -65,7 +63,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -87,7 +84,7 @@
         }));
       },
 
-      back: function () { app.show_tabpane('add_modify'); },
+      back: function () { this.$parent.show_tabpane('add_modify'); },
     },
     ready: function () {
       var self = this;
@@ -103,7 +100,7 @@
         _.each(data, function (val, key) {
           Vue.set(self.result, key, val.Default);
         });
-        app.loading = false;
+        self.$parent.loading = false;
 
         Vue.nextTick(function () {
           var inputs = $(self.$el).parent().find('input');
@@ -163,7 +160,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -209,7 +205,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -260,7 +255,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -505,7 +499,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -717,7 +710,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -781,7 +773,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -1028,7 +1019,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -1064,7 +1054,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -1120,7 +1109,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -1234,7 +1222,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -1798,7 +1785,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -1906,7 +1892,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -1965,7 +1950,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -2057,7 +2041,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 
@@ -2154,7 +2137,6 @@
       infra_id: {
         type: Number,
         required: true,
-        twoWay: true,
       },
     },
 

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -2510,47 +2510,47 @@
 
   // for infrastructures#new
   var new_ec2_key = function () {
-    modal.Confirm(t('infrastructures.infrastructure'), t('ec2_private_keys.confirm.create')).done(function () {
-      modal.Prompt(t('infrastructures.infrastructure'), t('app_settings.keypair_name')).done(function (name) {
-        if(!name){
-          modal.Alert(t('infrastructures.infrastructure'), t('ec2_private_keys.msg.please_name'), 'danger');
-          return;
-        }
+    modal.Confirm(t('infrastructures.infrastructure'), t('ec2_private_keys.confirm.create')).then(function () {
+      return modal.Prompt(t('infrastructures.infrastructure'), t('app_settings.keypair_name'));
+    }).then(function (name) {
+      if(!name){
+        modal.Alert(t('infrastructures.infrastructure'), t('ec2_private_keys.msg.please_name'), 'danger');
+        return;
+      }
 
-        var region_input = $('#infrastructure_region');
-        var region = region_input.val();
-        var project_id = $('#infrastructure_project_id').val();
+      var region_input = $('#infrastructure_region');
+      var region = region_input.val();
+      var project_id = $('#infrastructure_project_id').val();
 
-        $.ajax({
-          url: '/ec2_private_keys',
-          type: 'POST',
-          data: {
-            name:       name,
-            region:     region,
-            project_id: project_id,
-          },
-        }).done(function (key) {
-          var value = key.value;
-          var textarea = $('#keypair_value');
-          var keypair_name = $('#keypair_name');
-          textarea.val(value);
-          textarea.attr('readonly', true);
-          keypair_name.val(name);
-          keypair_name.attr('readonly', true);
-          region_input.attr('readonly', true);
-
-          // download file.
-          var file = new File([value], name + '.pem');
-          var url = window.URL.createObjectURL(file);
-          var a = document.createElement('a');
-          a.href = url;
-          a.setAttribute('download', file.name);
-          document.body.appendChild(a);
-          a.click();
-        }).fail(function (xhr) {
-          modal.Alert(t('infrastructures.infrastructure'), xhr.responseText, 'danger');
-        });
+      return $.ajax({
+        url: '/ec2_private_keys',
+        type: 'POST',
+        data: {
+          name:       name,
+          region:     region,
+          project_id: project_id,
+        },
       });
+    }).done(function (key) {
+      var value = key.value;
+      var textarea = $('#keypair_value');
+      var keypair_name = $('#keypair_name');
+      textarea.val(value);
+      textarea.attr('readonly', true);
+      keypair_name.val(name);
+      keypair_name.attr('readonly', true);
+      region_input.attr('readonly', true);
+
+      // download file.
+      var file = new File([value], name + '.pem');
+      var url = window.URL.createObjectURL(file);
+      var a = document.createElement('a');
+      a.href = url;
+      a.setAttribute('download', file.name);
+      document.body.appendChild(a);
+      a.click();
+    }).fail(function (xhr) {
+      modal.Alert(t('infrastructures.infrastructure'), xhr.responseText, 'danger');
     });
   };
 

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -48,11 +48,11 @@
   Vue.use(vace, false, 'json', '25');
 
   var helpers = require('infrastructures/helper.js');
-  var jsonParseErr         = jsonParseErr;
-  var toLocaleString       = toLocaleString;
-  var alert_success        = alert_success;
-  var alert_danger         = alert_danger;
-  var alert_and_show_infra = alert_and_show_infra;
+  var jsonParseErr         = helpers.jsonParseErr;
+  var toLocaleString       = helpers.toLocaleString;
+  var alert_success        = helpers.alert_success;
+  var alert_danger         = helpers.alert_danger;
+  var alert_and_show_infra = helpers.alert_and_show_infra;
 
 
   Vue.component("stack-events-table", {

--- a/app/assets/javascripts/infrastructures.js
+++ b/app/assets/javascripts/infrastructures.js
@@ -2327,69 +2327,71 @@
     },
     methods: {
       sortBy: function (key) {
-          if(key !== 'id')
-            this.sortKey = key;
-            this.sortOrders[key] = this.sortOrders[key] * -1;
+        if(key !== 'id')
+          this.sortKey = key;
+        this.sortOrders[key] = this.sortOrders[key] * -1;
       },
       showPrev: function(){
-          if(this.pageNumber === 0) return;
-          this.pageNumber--;
+        if(this.pageNumber === 0) return;
+        this.pageNumber--;
       },
       showNext: function(){
-          if(this.isEndPage) return;
-          this.pageNumber++;
+        if(this.isEndPage) return;
+        this.pageNumber++;
       },
     },
     computed: {
       isStartPage: function(){
-          return (this.pageNumber === 0);
+        return (this.pageNumber === 0);
       },
       isEndPage: function(){
-          return ((this.pageNumber + 1) * this.pages >= this.data.length);
+        return ((this.pageNumber + 1) * this.pages >= this.data.length);
       },
     },
     created: function (){
-        var self = this;
-        self.loading = true;
-        var id =  queryString.project_id;
-        var monthNames = ["January", "February", "March", "April", "May", "June",
-                          "July", "August", "September", "October", "November", "December"
-                          ];
-       $.ajax({
-           cache: false,
-           url:'/infrastructures?&project_id='+id,
-           success: function (data) {
-             this.pages = data.length;
-             var nextColumns = [];
-             self.data = data.map(function (item) {
-                 var d = new Date(item.created_at);
-                 var date = monthNames[d.getUTCMonth()]+' '+d.getDate()+', '+d.getFullYear()+' at '+d.getHours()+':'+d.getMinutes();
-                 if(item.project_id > 3){
-                   return {stack_name: item.stack_name,
-                       region: item.region,
-                       keypairname: item.keypairname,
-                       created_at: date,
-                       //  ec2_private_key_id: item.ec2_private_key_id,
-                       status: item.status,
-                       id: [item.id,item.status],
-                       };
-                 }else{
-                   return {stack_name: item.stack_name,
-                           region: item.region,
-                           keypairname: item.keypairname,
-                           //  ec2_private_key_id: item.ec2_private_key_id,
-                           id: [item.id,item.status],
-                   };
-                 }
-                 self.loading = false;
-               });
-             self.$emit('data-loaded');
-             $("#loading").hide();
-             var empty = t('infrastructures.msg.empty-list');
-             if(self.data.length === 0){ $('#empty').show().html(empty);}
-             self.filteredLength = data.length;
-           }
-         });
+      var self = this;
+      self.loading = true;
+      var id =  queryString.project_id;
+      var monthNames = [
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December"
+      ];
+      $.ajax({
+        cache: false,
+        url:'/infrastructures?&project_id='+id,
+      }).done(function (data) {
+        this.pages = data.length;
+        var nextColumns = [];
+        self.data = data.map(function (item) {
+          var d = new Date(item.created_at);
+          var date = monthNames[d.getUTCMonth()]+' '+d.getDate()+', '+d.getFullYear()+' at '+d.getHours()+':'+d.getMinutes();
+          if(item.project_id > 3){
+            return {
+              stack_name: item.stack_name,
+              region: item.region,
+              keypairname: item.keypairname,
+              created_at: date,
+              //  ec2_private_key_id: item.ec2_private_key_id,
+              status: item.status,
+              id: [item.id,item.status],
+            };
+          }else{
+            return {
+              stack_name: item.stack_name,
+              region: item.region,
+              keypairname: item.keypairname,
+              //  ec2_private_key_id: item.ec2_private_key_id,
+              id: [item.id,item.status],
+            };
+          }
+          self.loading = false;
+        });
+        self.$emit('data-loaded');
+        $("#loading").hide();
+        var empty = t('infrastructures.msg.empty-list');
+        if(self.data.length === 0){ $('#empty').show().html(empty);}
+        self.filteredLength = data.length;
+      });
     },
     filters:{
       wrap: wrap,
@@ -2406,7 +2408,7 @@
         return arr;
       },
     }
- });
+  });
 
 
   var stack_in_progress = function (infra) {

--- a/app/assets/javascripts/infrastructures/add-modify-tabpane.js
+++ b/app/assets/javascripts/infrastructures/add-modify-tabpane.js
@@ -1,0 +1,42 @@
+var jsonParseErr = require('./helper.js').jsonParseErr;
+
+module.exports = Vue.extend({
+  props: {
+    templates: {
+      type: Object,
+      required: true,
+    },
+    result: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  data: function() {return {
+    selected_cft_id: null,
+  };},
+
+  template: '#add-modify-tabpane-template',
+
+  methods: {
+    select_cft: function () {
+      var self = this;
+      var cft = _.find(self.templates.histories.concat(self.templates.globals), function (c) {
+        return c.id === self.selected_cft_id;
+      });
+      self.result.name   = cft.name;
+      self.result.detail = cft.detail;
+      self.result.value  = cft.value;
+    },
+
+    submit: function () {
+      if (this.jsonParseErr) {return;}
+      this.$parent.show_tabpane('insert-cf-params');
+      this.$parent.loading = true;
+    },
+  },
+
+  computed: {
+    jsonParseErr: function () { return jsonParseErr(this.result.value); },
+  },
+});

--- a/app/assets/javascripts/infrastructures/helper.js
+++ b/app/assets/javascripts/infrastructures/helper.js
@@ -1,0 +1,50 @@
+// Vueに登録したfilterを、外から見る方法ってないのかな。
+var jsonParseErr = function (str) {
+  if (_.trim(str) === '') {
+    return 'JSON String is empty. Please input JSON.';
+  }
+  try {
+    JSON.parse(str);
+  } catch (ex) {
+    return ex;
+  }
+};
+
+var toLocaleString = function (datetext) {
+  var date = new Date(datetext);
+  return date.toLocaleString();
+};
+
+
+// Utilities
+var alert_success = function (callback) {
+  return function (msg) {
+    var dfd = modal.Alert(t('infrastructures.infrastructure'), msg);
+    if (callback) {
+      dfd.done(callback);
+    }
+  };
+};
+
+var alert_danger = function (callback) {
+  return function (msg) {
+    if (!jsonParseErr(msg) && JSON.parse(msg).error) {
+      modal.AlertForAjaxStdError(callback)(msg);
+    } else {
+      var dfd = modal.Alert(t('infrastructures.infrastructure'), msg, 'danger');
+      if (callback) { dfd.done(callback); }
+    }
+  };
+};
+
+var alert_and_show_infra = alert_danger(function () {
+  show_infra(current_infra.id);
+});
+
+module.exports = {
+  jsonParseErr:         jsonParseErr,
+  toLocaleString:       toLocaleString,
+  alert_success:        alert_success,
+  alert_danger:         alert_danger,
+  alert_and_show_infra: alert_and_show_infra,
+};

--- a/app/assets/javascripts/infrastructures/helper.js
+++ b/app/assets/javascripts/infrastructures/helper.js
@@ -1,3 +1,5 @@
+var modal = require('modal');
+
 // Vueに登録したfilterを、外から見る方法ってないのかな。
 var jsonParseErr = function (str) {
   if (_.trim(str) === '') {

--- a/app/assets/javascripts/infrastructures/show_infra.js
+++ b/app/assets/javascripts/infrastructures/show_infra.js
@@ -1,0 +1,31 @@
+var Infrastructure = require('models/infrastructure').default;
+var newVM = require('modules/newVM');
+
+
+var SHOW_INFRA_ID = '#infra-show';
+var app;
+
+var show_infra = function (infra_id, current_tab) {
+  var infra = new Infrastructure(infra_id);
+
+  var l = new Loader();
+  l.text = "Loading...";
+  l.$mount(SHOW_INFRA_ID);
+  if (app) {
+    app.$destroy();
+  }
+  infra.show().done(function (stack) {
+    app = newVM(
+      stack,
+      infra,
+      current_tab
+    );
+    l.$destroy();
+    app.$mount(SHOW_INFRA_ID);
+  });
+};
+
+module.exports = {
+  SHOW_INFRA_ID: SHOW_INFRA_ID,
+  show_infra: show_infra
+};

--- a/app/assets/javascripts/infrastructures/stack-events-table.js
+++ b/app/assets/javascripts/infrastructures/stack-events-table.js
@@ -1,3 +1,5 @@
+var toLocaleString = require('./helper.js').toLocaleString;
+
 module.exports = Vue.extend({
   props: { events: Array, },
   template: '#stack-events-table-template',

--- a/app/assets/javascripts/infrastructures/stack-events-table.js
+++ b/app/assets/javascripts/infrastructures/stack-events-table.js
@@ -1,0 +1,20 @@
+module.exports = Vue.extend({
+  props: { events: Array, },
+  template: '#stack-events-table-template',
+  methods: {
+    event_tr_class: function (status) {
+      if      (status === "CREATE_COMPLETE")    { return "success"; }
+      else if (status.indexOf("FAILED") !== -1) { return "danger"; }
+      else if (status.indexOf("DELETE") !== -1) { return "warning"; }
+      return '';
+    },
+    toLocaleString: toLocaleString,
+  },
+  created: function () {
+    var self = this;
+    console.log(self);
+    this.$watch('events', function () {
+      $(self.$el).hide().fadeIn(800);
+    });
+  },
+});

--- a/app/assets/javascripts/modules/newVM.js
+++ b/app/assets/javascripts/modules/newVM.js
@@ -11,6 +11,7 @@ module.exports = function (stack, Resource, EC2Instance, current_infra, CFTempla
     template: '#infra-show-template',
     data: {
       current_infra: {
+        id: parseInt(current_infra.id),
         stack: stack,
         resources : {},
         events: [],

--- a/app/assets/javascripts/modules/newVM.js
+++ b/app/assets/javascripts/modules/newVM.js
@@ -11,7 +11,6 @@ var Resource     = require('models/resource').default;
 var EC2Instance  = require('models/ec2_instance').default;
 var helpers      = require('infrastructures/helper.js');
 var alert_danger = helpers.alert_danger;
-var show_infra   = require('infrastructures/show_infra.js').show_infra;
 
 
 module.exports = function (stack, current_infra, current_tab) {
@@ -167,6 +166,7 @@ module.exports = function (stack, current_infra, current_tab) {
               self.stack_in_progress(current_infra);
             }, 15000);
           } else {
+            var show_infra = require('infrastructures/show_infra.js').show_infra;
             show_infra(current_infra.id);
           }
         });

--- a/app/assets/javascripts/modules/newVM.js
+++ b/app/assets/javascripts/modules/newVM.js
@@ -6,7 +6,15 @@
 // http://opensource.org/licenses/mit-license.php
 //
 
-module.exports = function (stack, Resource, EC2Instance, current_infra, CFTemplate, alert_danger, current_tab) {
+var CFTemplate   = require('models/cf_template').default;
+var Resource     = require('models/resource').default;
+var EC2Instance  = require('models/ec2_instance').default;
+var helpers      = require('infrastructures/helper.js');
+var alert_danger = helpers.alert_danger;
+var show_infra   = require('infrastructures/show_infra.js').show_infra;
+
+
+module.exports = function (stack, current_infra, current_tab) {
   return new Vue({
     template: '#infra-show-template',
     data: {

--- a/app/views/infrastructures/_show.html.erb
+++ b/app/views/infrastructures/_show.html.erb
@@ -83,25 +83,25 @@
       </div>
 
       <div v-show="!loading">
-        <add-modify-tabpane      v-if="tabpane_active('add_modify')"       :templates.once="current_infra.templates" :result.sync="current_infra.add_modify"></add-modify-tabpane>
-        <insert-cf-params        v-if="tabpane_active('insert-cf-params')" ></insert-cf-params>
-        <add-ec2-tabpane         v-if="tabpane_active('add-ec2')"          ></add-ec2-tabpane>
-        <cf-history-tabpane      v-if="tabpane_active('cf_history')"       ></cf-history-tabpane>
-        <stack-events-table      v-if="tabpane_active('event_logs')"       :events.once="current_infra.events"></stack-events-table>
-        <security-groups-tabpane v-if="tabpane_active('security_groups')"  :ec2_instances.once="current_infra.resources.ec2_instances"></security-groups-tabpane>
-        <monitoring-tabpane      v-if="tabpane_active('monitoring')"       ></monitoring-tabpane>
-        <edit-monitoring-tabpane v-if="tabpane_active('edit-monitoring')"  ></edit-monitoring-tabpane>
-        <infra-logs-tabpane      v-if="tabpane_active('infra_logs')"       ></infra-logs-tabpane>
-        <ec2-tabpane             v-if="tabpane_active('ec2')"              :physical_id.once="tabpaneGroupID"></ec2-tabpane>
-        <rds-tabpane             v-if="tabpane_active('rds')"              :physical_id.once="tabpaneGroupID"></rds-tabpane>
-        <elb-tabpane             v-if="tabpane_active('elb')"              :physical_id.once="tabpaneGroupID"></elb-tabpane>
-        <s3-tabpane              v-if="tabpane_active('s3')"               :physical_id.once="tabpaneGroupID"></s3-tabpane>
-        <edit-runlist-tabpane    v-if="tabpane_active('edit_runlist')"     ></edit-runlist-tabpane>
-        <edit-attr-tabpane       v-if="tabpane_active('edit_attr')"        ></edit-attr-tabpane>
-        <serverspec-tabpane      v-if="tabpane_active('serverspec')"       ></serverspec-tabpane>
-        <serverspec-results-tabpane v-if="tabpane_active('serverspec_results')"   :columns.once="spec_Columns" :physical_id.once="tabpaneGroupID"   ></serverspec-results-tabpane>
-        <operation-sched-tabpane v-if="tabpane_active('operation-sched')" :columns.once="ops_sched_Columns"></operation-sched-tabpane>
-        <view-rules-tabpane v-if="tabpane_active('view-rules')" :security_groups.once="sec_group" :physical_id.once="tabpaneGroupID" :instance_type.once="instance_type"></view-rules-tabpane>
+        <add-modify-tabpane         v-if="tabpane_active('add_modify')"         :templates.once="current_infra.templates" :result.sync="current_infra.add_modify"></add-modify-tabpane>
+        <insert-cf-params           v-if="tabpane_active('insert-cf-params')"   :infra_id.sync="current_infra.id"></insert-cf-params>
+        <add-ec2-tabpane            v-if="tabpane_active('add-ec2')"            :infra_id.sync="current_infra.id"></add-ec2-tabpane>
+        <cf-history-tabpane         v-if="tabpane_active('cf_history')"         :infra_id.sync="current_infra.id"></cf-history-tabpane>
+        <stack-events-table         v-if="tabpane_active('event_logs')"         :events.once="current_infra.events"></stack-events-table>
+        <security-groups-tabpane    v-if="tabpane_active('security_groups')"    :infra_id.sync="current_infra.id" :ec2_instances.once="current_infra.resources.ec2_instances"></security-groups-tabpane>
+        <monitoring-tabpane         v-if="tabpane_active('monitoring')"         :infra_id.sync="current_infra.id"></monitoring-tabpane>
+        <edit-monitoring-tabpane    v-if="tabpane_active('edit-monitoring')"    :infra_id.sync="current_infra.id"></edit-monitoring-tabpane>
+        <infra-logs-tabpane         v-if="tabpane_active('infra_logs')"         :infra_id.sync="current_infra.id"></infra-logs-tabpane>
+        <ec2-tabpane                v-if="tabpane_active('ec2')"                :infra_id.sync="current_infra.id" :physical_id.once="tabpaneGroupID"></ec2-tabpane>
+        <rds-tabpane                v-if="tabpane_active('rds')"                :infra_id.sync="current_infra.id" :physical_id.once="tabpaneGroupID"></rds-tabpane>
+        <elb-tabpane                v-if="tabpane_active('elb')"                :infra_id.sync="current_infra.id" :physical_id.once="tabpaneGroupID"></elb-tabpane>
+        <s3-tabpane                 v-if="tabpane_active('s3')"                 :infra_id.sync="current_infra.id" :physical_id.once="tabpaneGroupID"></s3-tabpane>
+        <edit-runlist-tabpane       v-if="tabpane_active('edit_runlist')"       :infra_id.sync="current_infra.id" ></edit-runlist-tabpane>
+        <edit-attr-tabpane          v-if="tabpane_active('edit_attr')"          :infra_id.sync="current_infra.id" ></edit-attr-tabpane>
+        <serverspec-tabpane         v-if="tabpane_active('serverspec')"         :infra_id.sync="current_infra.id" ></serverspec-tabpane>
+        <serverspec-results-tabpane v-if="tabpane_active('serverspec_results')" :infra_id.sync="current_infra.id" :columns.once="spec_Columns" :physical_id.once="tabpaneGroupID"   ></serverspec-results-tabpane>
+        <operation-sched-tabpane    v-if="tabpane_active('operation-sched')"    :infra_id.sync="current_infra.id" :columns.once="ops_sched_Columns"></operation-sched-tabpane>
+        <view-rules-tabpane         v-if="tabpane_active('view-rules')"         :infra_id.sync="current_infra.id" :security_groups.once="sec_group" :physical_id.once="tabpaneGroupID" :instance_type.once="instance_type"></view-rules-tabpane>
     </div>
   </div>
 </div>

--- a/app/views/infrastructures/_show.html.erb
+++ b/app/views/infrastructures/_show.html.erb
@@ -84,24 +84,24 @@
 
       <div v-show="!loading">
         <add-modify-tabpane         v-if="tabpane_active('add_modify')"         :templates.once="current_infra.templates" :result.sync="current_infra.add_modify"></add-modify-tabpane>
-        <insert-cf-params           v-if="tabpane_active('insert-cf-params')"   :infra_id.sync="current_infra.id"></insert-cf-params>
-        <add-ec2-tabpane            v-if="tabpane_active('add-ec2')"            :infra_id.sync="current_infra.id"></add-ec2-tabpane>
-        <cf-history-tabpane         v-if="tabpane_active('cf_history')"         :infra_id.sync="current_infra.id"></cf-history-tabpane>
+        <insert-cf-params           v-if="tabpane_active('insert-cf-params')"   :infra_id.once="current_infra.id"></insert-cf-params>
+        <add-ec2-tabpane            v-if="tabpane_active('add-ec2')"            :infra_id.once="current_infra.id"></add-ec2-tabpane>
+        <cf-history-tabpane         v-if="tabpane_active('cf_history')"         :infra_id.once="current_infra.id"></cf-history-tabpane>
         <stack-events-table         v-if="tabpane_active('event_logs')"         :events.once="current_infra.events"></stack-events-table>
-        <security-groups-tabpane    v-if="tabpane_active('security_groups')"    :infra_id.sync="current_infra.id" :ec2_instances.once="current_infra.resources.ec2_instances"></security-groups-tabpane>
-        <monitoring-tabpane         v-if="tabpane_active('monitoring')"         :infra_id.sync="current_infra.id"></monitoring-tabpane>
-        <edit-monitoring-tabpane    v-if="tabpane_active('edit-monitoring')"    :infra_id.sync="current_infra.id"></edit-monitoring-tabpane>
-        <infra-logs-tabpane         v-if="tabpane_active('infra_logs')"         :infra_id.sync="current_infra.id"></infra-logs-tabpane>
-        <ec2-tabpane                v-if="tabpane_active('ec2')"                :infra_id.sync="current_infra.id" :physical_id.once="tabpaneGroupID"></ec2-tabpane>
-        <rds-tabpane                v-if="tabpane_active('rds')"                :infra_id.sync="current_infra.id" :physical_id.once="tabpaneGroupID"></rds-tabpane>
-        <elb-tabpane                v-if="tabpane_active('elb')"                :infra_id.sync="current_infra.id" :physical_id.once="tabpaneGroupID"></elb-tabpane>
-        <s3-tabpane                 v-if="tabpane_active('s3')"                 :infra_id.sync="current_infra.id" :physical_id.once="tabpaneGroupID"></s3-tabpane>
-        <edit-runlist-tabpane       v-if="tabpane_active('edit_runlist')"       :infra_id.sync="current_infra.id" ></edit-runlist-tabpane>
-        <edit-attr-tabpane          v-if="tabpane_active('edit_attr')"          :infra_id.sync="current_infra.id" ></edit-attr-tabpane>
-        <serverspec-tabpane         v-if="tabpane_active('serverspec')"         :infra_id.sync="current_infra.id" ></serverspec-tabpane>
-        <serverspec-results-tabpane v-if="tabpane_active('serverspec_results')" :infra_id.sync="current_infra.id" :columns.once="spec_Columns" :physical_id.once="tabpaneGroupID"   ></serverspec-results-tabpane>
-        <operation-sched-tabpane    v-if="tabpane_active('operation-sched')"    :infra_id.sync="current_infra.id" :columns.once="ops_sched_Columns"></operation-sched-tabpane>
-        <view-rules-tabpane         v-if="tabpane_active('view-rules')"         :infra_id.sync="current_infra.id" :security_groups.once="sec_group" :physical_id.once="tabpaneGroupID" :instance_type.once="instance_type"></view-rules-tabpane>
+        <security-groups-tabpane    v-if="tabpane_active('security_groups')"    :infra_id.once="current_infra.id" :ec2_instances.once="current_infra.resources.ec2_instances"></security-groups-tabpane>
+        <monitoring-tabpane         v-if="tabpane_active('monitoring')"         :infra_id.once="current_infra.id"></monitoring-tabpane>
+        <edit-monitoring-tabpane    v-if="tabpane_active('edit-monitoring')"    :infra_id.once="current_infra.id"></edit-monitoring-tabpane>
+        <infra-logs-tabpane         v-if="tabpane_active('infra_logs')"         :infra_id.once="current_infra.id"></infra-logs-tabpane>
+        <ec2-tabpane                v-if="tabpane_active('ec2')"                :infra_id.once="current_infra.id" :physical_id.once="tabpaneGroupID"></ec2-tabpane>
+        <rds-tabpane                v-if="tabpane_active('rds')"                :infra_id.once="current_infra.id" :physical_id.once="tabpaneGroupID"></rds-tabpane>
+        <elb-tabpane                v-if="tabpane_active('elb')"                :infra_id.once="current_infra.id" :physical_id.once="tabpaneGroupID"></elb-tabpane>
+        <s3-tabpane                 v-if="tabpane_active('s3')"                 :infra_id.once="current_infra.id" :physical_id.once="tabpaneGroupID"></s3-tabpane>
+        <edit-runlist-tabpane       v-if="tabpane_active('edit_runlist')"       :infra_id.once="current_infra.id" ></edit-runlist-tabpane>
+        <edit-attr-tabpane          v-if="tabpane_active('edit_attr')"          :infra_id.once="current_infra.id" ></edit-attr-tabpane>
+        <serverspec-tabpane         v-if="tabpane_active('serverspec')"         :infra_id.once="current_infra.id" ></serverspec-tabpane>
+        <serverspec-results-tabpane v-if="tabpane_active('serverspec_results')" :infra_id.once="current_infra.id" :columns.once="spec_Columns" :physical_id.once="tabpaneGroupID"   ></serverspec-results-tabpane>
+        <operation-sched-tabpane    v-if="tabpane_active('operation-sched')"    :infra_id.once="current_infra.id" :columns.once="ops_sched_Columns"></operation-sched-tabpane>
+        <view-rules-tabpane         v-if="tabpane_active('view-rules')"         :infra_id.once="current_infra.id" :security_groups.once="sec_group" :physical_id.once="tabpaneGroupID" :instance_type.once="instance_type"></view-rules-tabpane>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Goal
---------

- [x] split components
  - [x] stack-events-tabpane
  - [x] add-modify-tabpane
- [x] `current_infra`変数 をグローバル変数から外す
- [x] `app` 変数をグローバル変数から外す


Next Goal
-------

- Split files other components

current_infra
--------

- グローバル変数から`current_infra`を消す
- 現在`current_infra`を必要としている component には、infra_id を prop として渡すようにする。
- `current_infra` に相当するものが必要になったら、`new Infrastructure(infra_id)`する

app
------

- グローバル変数から`app`を消す
- `app`に相当するものが必要になったら、`this.$parent`を参照する。
  - あまりいい手ではない気がするけど、グローバル変数よりマシ

