### PR TITLE
mkdir ~/.ssh if not exists

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -66,6 +66,10 @@ knife bootstrap #{fqdn} \
       cmd.chomp!
       cmd.concat(" --bootstrap-version #{chef_client_version}")
     end
+
+    ssh_dir = File.expand_path('~/.ssh')
+    Dir.mkdir(ssh_dir) unless Dir.exist?(ssh_dir)
+
     exec_command(cmd, BootstrapError)
 
     return self.new(node_name)

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -68,7 +68,7 @@ knife bootstrap #{fqdn} \
     end
 
     ssh_dir = File.expand_path('~/.ssh')
-    Dir.mkdir(ssh_dir) unless Dir.exist?(ssh_dir)
+    Dir.mkdir(ssh_dir, 0700) unless Dir.exist?(ssh_dir)
 
     exec_command(cmd, BootstrapError)
 


### PR DESCRIPTION
If ~/.ssh does not exist, host key is not registered to ~/.ssh/known_hosts.