### PR TITLE
NC-632

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,10 @@
       I18n.locale = "<%= I18n.locale %>";
     </script>
     <%= javascript_include_tag "application" %>
-    <%= javascript_include_tag controller.controller_name %>
+
+    <% controller_name = controller.controller_name %>
+    <% if Rails.application.assets.find_asset(controller_name) %>
+      <%= javascript_include_tag controller_name %>
+    <% end %>
   </body>
 </html>


### PR DESCRIPTION
It prevents loading an asset which is not present.

ref: https://skyarch.backlog.jp/view/NC-632