### PR TITLE
Servertests Improvements

### DIFF
--- a/app/assets/javascripts/infrastructures/operation-sched-tabpane.js
+++ b/app/assets/javascripts/infrastructures/operation-sched-tabpane.js
@@ -270,7 +270,7 @@ module.exports = Vue.extend({
 
       self.$parent.loading = false;
       $("#loading_results").hide();
-      var empty = t('serverspecs.msg.empty-results');
+      var empty = t('servertests.msg.empty-results');
       if(self.data.length === 0){ $('#empty_results').show().html(empty);}
   },
 });

--- a/app/assets/javascripts/modules/listen.js
+++ b/app/assets/javascripts/modules/listen.js
@@ -119,7 +119,10 @@
         }else{ return value; }
         break;
       case 'servertest':
-        return  (value.length > 0) ? value.map(function(val){ return val.name; }) : 'auto generated';
+        if (value.length > 0)
+          return value.map(function (val){ return val.name; }).join(', ');
+        else
+          return 'auto generated';
       case 'category':
         var category = [];
         value.forEach(function (argument) {

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -346,7 +346,7 @@ class Node
 
     case result[:status_text]
       when 'pending'
-        result[:message] = result[:examples].select{|x| x[:status] == 'pending'}.map{|x| x[:full_description]+"\n"+x[:pending_message]}.join("\n")
+        result[:message] = result[:examples].select{|x| x[:status] == 'pending'}.map{|x| "#{x[:full_description]}\n#{x[:pending_message]}"}.join("\n")
         result[:short_msg] = result[:examples].select{|x| x[:status] == 'failed'}.map{|x| x[:full_description]}.join("\n")
       when 'failed'
         result[:message] = result[:examples].select{|x| x[:status] == 'failed'}.map{|x| "#{x[:full_description]}\n#{x[:command]}¥n#{x[:exception][:message]}"}.join("\n")

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -346,10 +346,10 @@ class Node
 
     case result[:status_text]
       when 'pending'
-        result[:message] = result[:examples].select{|x| x[:status] == 'pending'}.map{|x| x[:full_description]+"\n"+x[:command]+"\n"+x[:exception][:message]}.join("\n")
-        result[:short_msg] = result[:examples].select{|x| x[:status] == 'failed'},map{|x| x[:full_description]}.join("\n")
+        result[:message] = result[:examples].select{|x| x[:status] == 'pending'}.map{|x| "#{x[:full_description]}\n#{x[:command]}¥n#{x[:exception][:message]}"}.join("\n")
+        result[:short_msg] = result[:examples].select{|x| x[:status] == 'failed'}.map{|x| x[:full_description]}.join("\n")
       when 'failed'
-        result[:message] = result[:examples].select{|x| x[:status] == 'failed'}.map{|x| x[:full_description]+"\n"+x[:command]+"\n"+x[:exception][:message]}.join("\n")
+        result[:message] = result[:examples].select{|x| x[:status] == 'failed'}.map{|x| "#{x[:full_description]}\n#{x[:command]}¥n#{x[:exception][:message]}"}.join("\n")
         result[:short_msg] = result[:examples].select{|x| x[:status] == 'failed'}.map{|x| x[:full_description]}.join("\n")
     end
 

--- a/app/validators/ruby_validator.rb
+++ b/app/validators/ruby_validator.rb
@@ -13,7 +13,7 @@ class RubyValidator < ActiveModel::EachValidator
     begin
       RubyParser.parse(value)
     rescue => ex
-      msg = "#{I18n.t('serverspecs.msg.parseerr')} (#{ex.message})"
+      msg = "#{I18n.t('servertests.msg.parseerr')} (#{ex.message})"
       record.errors[attribute] << msg
     end
   end

--- a/app/views/dishes/_show.html.erb
+++ b/app/views/dishes/_show.html.erb
@@ -31,8 +31,8 @@
     <table class="table table-condensed">
       <thead>
         <tr>
-          <th><%= t('serverspecs.name') %></th>
-          <th><%= t('serverspecs.description') %></th>
+          <th><%= t('servertests.name') %></th>
+          <th><%= t('servertests.description') %></th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/servertests/_form.html.erb
+++ b/app/views/servertests/_form.html.erb
@@ -10,28 +10,28 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.label :name, t('serverspecs.name'), class: 'control-label col-sm-2'%>
+    <%= f.label :name, t('servertests.name'), class: 'control-label col-sm-2'%>
     <div class="col-sm-5">
       <%= f.text_field :name, class: 'form-control', required: true%>
     </div>
   </div>
 
   <div class="form-group">
-    <%= f.label :description, t('serverspecs.description'), class: 'control-label col-sm-2'%>
+    <%= f.label :description, t('servertests.description'), class: 'control-label col-sm-2'%>
     <div class="col-sm-5">
       <%= f.text_field :description, class: ' form-control text_field_no_validation'%>
     </div>
   </div>
 
   <div class="form-group">
-    <%= f.label :value, t('serverspecs.value'), class: 'control-label col-sm-2'%>
+    <%= f.label :value, t('servertests.value'), class: 'control-label col-sm-2'%>
     <div class="col-sm-5">
       <%= f.text_area :value, class: 'form-control', required: true%>
     </div>
   </div>
 
   <div class="form-group">
-    <%= f.label :value, t('serverspecs.category'), class: 'control-label col-sm-2'%>
+    <%= f.label :value, t('servertests.category'), class: 'control-label col-sm-2'%>
     <div class="col-sm-5">
       <%= f.radio_button(:category, :awspec) %>
       <%= label(:category, "Awspec") %>

--- a/app/views/servertests/edit.html.erb
+++ b/app/views/servertests/edit.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, I18n.t('serverspecs.serverspec')+" | "+I18n.t('helpers.titles.edit')) %>
+<% provide(:title, I18n.t('servertests.servertest')+" | "+I18n.t('helpers.titles.edit')) %>
 <%- model_class = Servertest -%>
 <div class="page-header">
   <h1><%=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize %></h1>

--- a/app/views/servertests/generator.html.erb
+++ b/app/views/servertests/generator.html.erb
@@ -1,7 +1,7 @@
-<% provide(:title, I18n.t('serverspecs.generator.title')) %>
+<% provide(:title, I18n.t('servertests.generator.title')) %>
 <div class="container">
   <h2 class="page-header">
-    <%=t('serverspecs.generator.title')%>
+    <%=t('servertests.generator.title')%>
     <% if @infra %>
       <small><%= ('for ' + link_to(@infra.stack_name, infrastructures_path(project_id: @infra.project_id, infrastructure_id: @infra.id))).html_safe %></small>
     <% end %>

--- a/app/views/servertests/new.html.erb
+++ b/app/views/servertests/new.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, I18n.t('serverspecs.serverspec')+" | "+I18n.t('helpers.titles.new')) %>
+<% provide(:title, I18n.t('servertests.servertest')+" | "+I18n.t('helpers.titles.new')) %>
 <%- model_class = Servertest -%>
 <div class="page-header">
   <h1><%=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize %></h1>

--- a/app/views/vue/_servertest_results_tabpane.html.erb
+++ b/app/views/vue/_servertest_results_tabpane.html.erb
@@ -6,12 +6,14 @@
     </form><hr>
   </div>
   <table class="table table-hover ssp">
-    <tr>
-      <th v-for="key in columns"
-        :class="{active: sortKey === key}" @click="sortBy(key)">
-        <text v-html="key | wrap index"></text>
+    <thead>
+      <tr>
+        <th v-for="key in columns"
+            :class="{active: sortKey === key}"
+            @click="sortBy(key)">
+          <text v-html="key | wrap index"></text>
           <span v-if="key !== 'id' && key !== 'role'" class="glyphicon pull-right" :class="sortOrders[key] > 0? 'glyphicon-chevron-down' : 'glyphicon-chevron-up'"></span>
-      </th>
+        </th>
       </tr>
     </thead>
     <tbody class="tbody-infra-log">


### PR DESCRIPTION
## Changes
### Serverside
* String でない可能性があるオブジェクトを `+` メソッドで連結せずに、式展開を使って文字列を生成するように変更

### Frontend
* Servertests の結果表示で、servertest 項目が多数ある場合に見辛くなる問題を修正
* マークアップの修正と整形
* Servertests 関連の多数の箇所で正しい翻訳が表示されない問題を修正