### PR TITLE
Fixed infrastructure resource status bug

### DIFF
--- a/app/controllers/infrastructures_controller.rb
+++ b/app/controllers/infrastructures_controller.rb
@@ -73,7 +73,7 @@ class InfrastructuresController < ApplicationController
       resp[:message] = stack.status[:message]
     end
 
-    if stack.update_complete?
+    if stack.update_complete? && @infrastructure.resources_updated?
       @infrastructure.resources.destroy_all
     end
 

--- a/app/models/infrastructure.rb
+++ b/app/models/infrastructure.rb
@@ -98,6 +98,17 @@ class Infrastructure < ActiveRecord::Base
     return self.resources
   end
 
+  # リソースが更新されているか否かを返す
+  # @return [Boolean]
+  def resources_updated?
+    old_physical_ids = self.resources.pluck(:physical_id)
+    stack = Stack.new(self)
+    now_physical_ids = stack.instances_for_resources.map{|aws_resource|
+      aws_resource.physical_resource_id
+    }
+    return old_physical_ids.sort != now_physical_ids.sort
+  end
+
   # AWS の access key を返す。
   # @return [String]
   def access_key

--- a/spec/controllers/infrastructures_controller_spec.rb
+++ b/spec/controllers/infrastructures_controller_spec.rb
@@ -103,13 +103,29 @@ describe InfrastructuresController, type: :controller do
           case action
           when "create", "update"
             if action == "update"
+              let(:resources_updated){false}
+
               before do
                 allow_any_instance_of(Infrastructure).to receive(:resources_or_create).and_return(infra.resources)
+                allow_any_instance_of(Infrastructure).to receive(:resources_updated?).and_return(resources_updated)
               end
 
-              it "should delete resource" do
-                infra.reload
-                expect(infra.resources).to be_empty
+              context 'when the resources is updated' do
+                let(:resources_updated){true}
+
+                it "should delete resource" do
+                  infra.reload
+                  expect(infra.resources).to be_empty
+                end
+              end
+
+              context 'when the resources is not updated' do
+                let(:resources_updated){false}
+
+                it "should not delete resource" do
+                  infra.reload
+                  expect(infra.resources).not_to be_empty
+                end
               end
             end
           end

--- a/spec/models/infrastructure_spec.rb
+++ b/spec/models/infrastructure_spec.rb
@@ -116,6 +116,38 @@ describe Infrastructure, type: :model do
     end
   end
 
+  describe '#resources_updated?' do
+    let(:infra){build(:infrastructure, resources: [])}
+    let(:resources){build_list(:ec2_resource, 3)}
+    subject{infra.resources_updated?}
+
+    before do
+      infra.resources = resources
+      infra.save!
+      allow_any_instance_of(Stack).to receive(:instances_for_resources).and_return(instances_for_resources)
+    end
+
+    context 'when there is a difference in physical_id of resources' do
+      let(:instances_for_resources){[]}
+
+      it 'shoud return true' do
+        is_expected.to eq true
+      end
+    end
+
+    context 'when there is not a difference in physical_id of resources' do
+      let(:instances_for_resources){resources.map{|resource|
+        resource_mock = double('resource')
+        allow(resource_mock).to receive(:physical_resource_id).and_return(resource.physical_id)
+        resource_mock
+      }}
+
+      it 'shoud return false' do
+        is_expected.to eq false
+      end
+    end
+  end
+
   describe '#access_key' do
     subject{build(:infrastructure)}
 


### PR DESCRIPTION
スタックのステータスがUPDATE_COMPLETEの場合にページをリロードするとリソースのステータスがUnExecutedに戻ってしまう不具合の修正