### PR TITLE
ChromeでセキュリティグループのPrintボタンが動作しなくなっていたのを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ vendor/bower_components
 /frontend/dest/
 /frontend/node_modules/
 /frontend/typings/
+/frontend/fonts/
 
 # MAC system files
 .DS_Store

--- a/app/assets/javascripts/infrastructures/view-rules-tabpane.js
+++ b/app/assets/javascripts/infrastructures/view-rules-tabpane.js
@@ -1,9 +1,11 @@
 var queryString    = require('query-string').parse(location.search);
 var Infrastructure = require('models/infrastructure').default;
 var EC2Instance    = require('models/ec2_instance').default;
-var createPdf      = require('pdfmake-browserified');
-var map            = require('../modules/ipam00303.map');
-var data_mapping   = require('../modules/ipam00303');
+var pdfMake      = require('pdfmake/build/pdfmake.js');
+var pdfFonts     = require('../modules/vfs_fonts.js');
+pdfMake.vfs = pdfFonts.pdfMake.vfs;
+var fontsMap    = require('../modules/fonts_map.js');
+pdfMake.fonts = fontsMap;
 var tableRender    = require('../modules/table_render');
 
 module.exports = Vue.extend({
@@ -66,7 +68,7 @@ module.exports = Vue.extend({
     },
     print_pdf: function(){
       var data = this.rules_summary;
-      var defaultFont = Object.keys(map)[0];
+      var defaultFont = Object.keys(fontsMap)[0];
 
       var docDefinition = {
         footer: function(currentPage, pageCount) {
@@ -126,7 +128,8 @@ module.exports = Vue.extend({
 
       };
 
-      createPdf(docDefinition, map, data_mapping).open();
+      pdfMake.createPdf(docDefinition).open();
+
       this.get_rules();
     },
     check_length: function(args){

--- a/app/assets/javascripts/modules/fonts_map.js
+++ b/app/assets/javascripts/modules/fonts_map.js
@@ -1,0 +1,1 @@
+../../../../frontend/fonts/fonts_map.js

--- a/app/assets/javascripts/modules/ipam00303.js
+++ b/app/assets/javascripts/modules/ipam00303.js
@@ -1,1 +1,0 @@
-../../../../vendor/bower_components/ipam00303/ipam00303.js

--- a/app/assets/javascripts/modules/ipam00303.map.js
+++ b/app/assets/javascripts/modules/ipam00303.map.js
@@ -1,1 +1,0 @@
-module.exports = {"ipam":{"normal":"ipam.ttf","bold":"ipam.ttf","italics":"ipam.ttf","bolditalics":"ipam.ttf"}};

--- a/app/assets/javascripts/modules/vfs_fonts.js
+++ b/app/assets/javascripts/modules/vfs_fonts.js
@@ -1,0 +1,1 @@
+../../../../frontend/fonts/vfs_fonts.js

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "bootswatch-dist": "paper",
     "ajax_set.js": "https://github.com/pocke/ajax_set.js.git#106d927aba64fa99220a1199973d41f2a448bd2c",
     "ws_proxy": "https://github.com/skyarch-networks/ws_proxy.git",
-    "ipam00303": "https://github.com/Joeper214/ipam00303.git",
     "noty": "~2.3.5",
     "animate.css": "~3.3.0",
     "jquery": "~2.1.4",

--- a/doc/installation/en/skyhopper.md
+++ b/doc/installation/en/skyhopper.md
@@ -218,6 +218,19 @@ $ gulp ts
 $ cd ..
 ```
 
+### Font download and build
+
+Details of the font to use: <https://github.com/m13253/kaigen-fonts>
+```sh
+$ cd frontend/fonts/
+$ curl -LO https://github.com/m13253/kaigen-fonts/releases/download/v1.004-1.001-1/KaigenSansJ.zip
+$ unzip KaigenSansJ.zip
+$ cd ..
+$ node build_font.js fonts/KaigenSansJ/KaigenSansJ-Regular.ttf
+$ cd ..
+```
+
+
 ### database.yml
 
 ```sh

--- a/doc/installation/skyhopper.md
+++ b/doc/installation/skyhopper.md
@@ -218,6 +218,18 @@ $ gulp ts
 $ cd ..
 ```
 
+### フォントのダウンロードとビルド
+
+使用するフォントの詳細: <https://github.com/m13253/kaigen-fonts>
+```sh
+$ cd frontend/fonts/
+$ curl -LO https://github.com/m13253/kaigen-fonts/releases/download/v1.004-1.001-1/KaigenSansJ.zip
+$ unzip KaigenSansJ.zip
+$ cd ..
+$ node build_font.js fonts/KaigenSansJ/KaigenSansJ-Regular.ttf
+$ cd ..
+```
+
 ### database.yml
 
 ```sh

--- a/frontend/build_font.js
+++ b/frontend/build_font.js
@@ -1,0 +1,28 @@
+var fs = require('fs');
+var path = require('path');
+var OUTPUT_VFS_FONTS_FILE_PATH = 'fonts/vfs_fonts.js';
+var OUTPUT_FONTS_MAP_FILE_PATH = 'fonts/fonts_map.js';
+
+var filePath = process.argv[2];
+var fileName = path.basename(filePath);
+
+// create vfs fonts file
+var data = fs.readFileSync(filePath, 'base64');
+var vfsObject = {};
+vfsObject[fileName] = data;
+var vfsFontsSourceCode = 'this.pdfMake = this.pdfMake || {}; this.pdfMake.vfs = ' + JSON.stringify(vfsObject) + ';';
+fs.writeFileSync(OUTPUT_VFS_FONTS_FILE_PATH,  vfsFontsSourceCode);
+console.log(OUTPUT_VFS_FONTS_FILE_PATH + ' has been created.');
+
+// create fonts map file
+var fontName = fileName.slice(0, -path.extname(fileName).length);
+var mapObject = {};
+mapObject[fontName] = {
+  normal: fileName,
+  bold: fileName,
+  italics: fileName,
+  bolditalics: fileName
+};
+var fontsMapSourceCode = 'module.exports = ' + JSON.stringify(mapObject) + ';';
+fs.writeFileSync(OUTPUT_FONTS_MAP_FILE_PATH,  fontsMapSourceCode);
+console.log(OUTPUT_FONTS_MAP_FILE_PATH + ' has been created.');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "jszip": "^3.0.0",
     "lodash": "^3.10.1",
     "md5": "^2.0.0",
-    "pdfmake-browserified": "^0.1.4",
+    "pdfmake": "^0.1.37",
     "query-string": "^2.4.1",
     "serverspec-generator": "^1.0.0",
     "vue": "~1.0.24",


### PR DESCRIPTION
ChromeでセキュリティグループのPrintボタンが動作しなくなっていたのを修正

詳細
PDF生成に使用していたライブラリをpdfmake-browserifiedからpdfmakeに変更
pdfmakeで使用できるようにフォントをビルドするスクリプトを追加
PDF出力に使用しているフォントをよくわからないものからKaigen Fontsに変更