### PR TITLE
Servertest編集画面から送信ボタンを押したときの画面遷移がおかしい不具合を修正

### DIFF
--- a/app/controllers/servertests_controller.rb
+++ b/app/controllers/servertests_controller.rb
@@ -49,7 +49,8 @@ class ServertestsController < ApplicationController
   # POST /servertests/1
   def update
     if @servertest.update(global_servertest_params)
-      redirect_to servertests_path, notice: I18n.t('servertests.msg.updated')
+      infra_id = @servertest.infrastructure_id
+      redirect_to servertests_path(infrastructure_id: infra_id), notice: I18n.t('servertests.msg.updated')
     else
       flash.now[:alert] = @servertest.errors[:value] if @servertest.errors[:value]
       render action: 'edit'


### PR DESCRIPTION
詳細
Servertest編集画面で送信ボタンを押したら、編集していたServertestのインフラストラクチャのServertest一覧画面に繊維するように修正