### PR TITLE
gitignoreに/public/javascripts/i18n.jsを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ vendor/bower_components
 
 # i18n-js
 /app/assets/javascripts/i18n/
+/public/javascripts/i18n.js
 
 /coverage/
 


### PR DESCRIPTION
gitignoreに/public/javascripts/i18n.jsを追加
/public/javascripts/i18n.jsは`rake i18n:js:export`で自動的に作成される。