### PR TITLE
Zabbixの切り離し

### DIFF
--- a/app/assets/javascripts/app_settings.js
+++ b/app/assets/javascripts/app_settings.js
@@ -15,7 +15,7 @@
 
 
   var endpoint_base = '/app_settings';
-  var inputs_selector = '#app-settings-form input[type=text],input[type=password],select,textarea';
+  var inputs_selector = '#app-settings-form input[type=text],input[type=password],select,textarea,input[type=checkbox]';
   var required_inputs = '#app-settings-form input[required],select[required],textarea[required]';
 
 
@@ -66,6 +66,10 @@
     $(inputs_selector).each(function () {
       var input = $(this);
       var key = input.attr('name');
+      if (input.is(':checkbox')) {
+        settings[key] = input.prop("checked");
+        return;
+      }
       var val = input.val();
       settings[key] = val;
     });

--- a/app/controllers/app_settings_controller.rb
+++ b/app/controllers/app_settings_controller.rb
@@ -19,6 +19,7 @@ class AppSettingsController < ApplicationController
   class SystemServerError < ::StandardError; end
 
   CF_PARAMS_KEY = 'cf_params'.freeze
+  CREATE_OPTIONS_KEY = 'create_options'.freeze
 
 
   # GET /app_settings
@@ -55,6 +56,9 @@ class AppSettingsController < ApplicationController
     check_eip_limit!
 
     Rails.cache.write(CF_PARAMS_KEY, cf_params)
+    Rails.cache.write(CREATE_OPTIONS_KEY, {
+      skip_zabbix_server: skip_zabbix_server
+    })
 
     ec2key = Ec2PrivateKey.create!(
       name:  keypair_name,
@@ -78,20 +82,6 @@ class AppSettingsController < ApplicationController
 
     projects.each do |project|
       project.update!(access_key: access_key, secret_access_key: secret_access_key)
-    end
-
-    Thread.new_with_db do
-      # おまじない
-      # rubocop:disable Lint/Void
-      ChefServer
-      ChefServer::Deployment
-      CfTemplate
-      # rubocop:enable Lint/Void
-
-      set = AppSetting.get
-      stack_name = "SkyHopperZabbixServer-#{Digest::MD5.hexdigest(DateTime.now.in_time_zone.to_s)}"
-
-      ChefServer::Deployment.create_zabbix(stack_name, set.aws_region, set.ec2_private_key.name, set.ec2_private_key.value, cf_params, skip_zabbix_server)
     end
 
     render text: I18n.t('app_settings.msg.created') and return
@@ -118,27 +108,49 @@ class AppSettingsController < ApplicationController
 
   # POST /app_settings/chef_create
   def chef_create
-    # とりあえず決め打ちでいい気がする
-    # stack_name = params.require(:stack_name)
-    stack_name = "SkyHopperChefServer-#{Digest::MD5.hexdigest(DateTime.now.in_time_zone.to_s)}"
-
     set = AppSetting.first
     region        = set.aws_region
     keypair_name  = set.ec2_private_key.name
     keypair_value = set.ec2_private_key.value
 
     @locale = I18n.locale
+
+    cf_params = Rails.cache.fetch(CF_PARAMS_KEY)
+    raise 'Failure to acquire cf_params' if cf_params.nil?
+    Rails.cache.delete(CF_PARAMS_KEY)
+
+    create_options = Rails.cache.fetch(CREATE_OPTIONS_KEY)
+    raise 'Failure to acquire create_options' if create_options.nil?
+    Rails.cache.delete(CREATE_OPTIONS_KEY)
+
     # おまじない
     # rubocop:disable Lint/Void
     ChefServer
     ChefServer::Deployment
     CfTemplate
+    Client
+    Infrastructure
+    Project
+    ProjectParameter
+    Stack
+    ZabbixServer
     # rubocop:enable Lint/Void
 
-    cf_params = Rails.cache.fetch(CF_PARAMS_KEY) || {}
-    Rails.cache.delete(CF_PARAMS_KEY)
+    unless create_options[:skip_zabbix_server]
+      # ZabbixServerの構築
+      create_zabbix_thread = Thread.new_with_db do
+        stack_name = "SkyHopperZabbixServer-#{Digest::MD5.hexdigest(DateTime.now.in_time_zone.to_s)}"
 
+        ChefServer::Deployment.create_zabbix(stack_name, region, keypair_name, keypair_value, cf_params)
+      end
+    end
+
+    # ChefServerの構築
     Thread.new_with_db do
+      # とりあえず決め打ちでいい気がする
+      # stack_name = params.require(:stack_name)
+      stack_name = "SkyHopperChefServer-#{Digest::MD5.hexdigest(DateTime.now.in_time_zone.to_s)}"
+
       ws = WSConnector.new('chef_server_deployment', 'status')
 
       begin
@@ -148,6 +160,17 @@ class AppSettingsController < ApplicationController
         end
 
         Rails.logger.debug("ChefServer creating > complete")
+
+        unless create_options[:skip_zabbix_server]
+          # ZabbixServerの作成完了を待つ
+          ws.push(build_ws_message(:wait_for_zabbix_created))
+          create_zabbix_thread.join
+        end
+
+        set.dummy = false
+        set.save!
+        AppSetting.clear_cache
+
         ws.push(build_ws_message(:complete))
       rescue => ex
         Rails.logger.error(ex.message)

--- a/app/controllers/app_settings_controller.rb
+++ b/app/controllers/app_settings_controller.rb
@@ -36,6 +36,7 @@ class AppSettingsController < ApplicationController
 
     vpc_id    = settings.delete(:vpc_id)
     subnet_id = settings.delete(:subnet_id)
+    skip_zabbix_server = settings.delete(:skip_zabbix_server)
 
     set_ec2(settings[:aws_region], access_key, secret_access_key)
 
@@ -90,7 +91,7 @@ class AppSettingsController < ApplicationController
       set = AppSetting.get
       stack_name = "SkyHopperZabbixServer-#{Digest::MD5.hexdigest(DateTime.now.in_time_zone.to_s)}"
 
-      ChefServer::Deployment.create_zabbix(stack_name, set.aws_region, set.ec2_private_key.name, set.ec2_private_key.value, cf_params)
+      ChefServer::Deployment.create_zabbix(stack_name, set.aws_region, set.ec2_private_key.name, set.ec2_private_key.value, cf_params, skip_zabbix_server)
     end
 
     render text: I18n.t('app_settings.msg.created') and return

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,8 +27,6 @@ class ProjectsController < ApplicationController
     authorize(@project || Project.new(client_id: client_id))
   end
 
-  before_action :with_zabbix, only: [:destroy, :create, :new]
-
   # GET /projects
   # GET /projects.json
   def index
@@ -82,11 +80,11 @@ class ProjectsController < ApplicationController
     }
 
     zid = project_params[:zabbix_server_id]
-    if zid.empty?
-      flash[:alert] = t('projects.msg.zabbix_not_set')
-      on_error.() and return
+    @zabbix = nil
+    if zid.present?
+      with_zabbix
+      @zabbix = ZabbixServer.find(zid)
     end
-    @zabbix = ZabbixServer.find(zid)
 
     @project = Project.new(project_params)
     unless @project.save
@@ -112,12 +110,11 @@ class ProjectsController < ApplicationController
   # PATCH/PUT /projects/1.json
   def update
     zid = project_params[:zabbix_server_id]
-    if zid.empty?
-      flash[:alert] = t('projects.msg.zabbix_not_set')
-      redirect_to edit_project_path and return
+    @zabbix = nil
+    if zid.present?
+      with_zabbix
+      @zabbix = ZabbixServer.find(zid)
     end
-
-    @zabbix = ZabbixServer.find(zid)
     if @project.update(project_params)
       @project.register_hosts(@zabbix, current_user)
       redirect_to projects_path(client_id: @project.client_id),

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -128,6 +128,9 @@ class ProjectsController < ApplicationController
   # DELETE /projects/1
   # DELETE /projects/1.json
   def destroy
+    if @project.zabbix_server_id.present?
+      with_zabbix
+    end
     go = -> (){redirect_to(projects_path(client_id: @project.client_id))}
     begin
       @project.destroy!

--- a/app/helpers/zabbix_servers_helper.rb
+++ b/app/helpers/zabbix_servers_helper.rb
@@ -6,8 +6,6 @@ module ZabbixServersHelper
 
   def delete_zabbix_server_path(zabbix_server, user: current_user)
     return nil unless Pundit.policy(user, zabbix_server).destroy?
-    # Exclude the default zabbix server from deletion
-    return nil if zabbix_server.id == 1
     return zabbix_server_path(zabbix_server)
   end
 end

--- a/app/models/chef_server/deployment.rb
+++ b/app/models/chef_server/deployment.rb
@@ -94,10 +94,17 @@ class ChefServer::Deployment
 
 
     # XXX: こぴぺをやめてここじゃないとこにちゃんと定義する
-    def create_zabbix(stack_name, region, keypair_name, keypair_value, params = {})
+    def create_zabbix(stack_name, region, keypair_name, keypair_value, params = {}, skip_creation = false)
       prj = Project.for_zabbix_server
       unless prj
         raise SystemServerError, I18n.t('app_settings.msg.db_seed_not_found', server: 'Zabbix')
+      end
+      if skip_creation
+        set = AppSetting.first
+        set.fqdn = nil
+        set.save!
+        AppSetting.clear_cache
+        return
       end
       infra = Infrastructure.create_with_ec2_private_key(
         project:       prj,

--- a/app/models/infrastructure.rb
+++ b/app/models/infrastructure.rb
@@ -153,7 +153,11 @@ class Infrastructure < ActiveRecord::Base
   end
 
   def detach_zabbix
-    s = ZabbixServer.find(self.project.zabbix_server_id)
+    zabbix_server_id = self.project.zabbix_server_id
+    if zabbix_server_id.nil?
+      return
+    end
+    s = ZabbixServer.find(zabbix_server_id)
     begin
       z = Zabbix.new(s.fqdn, s.username, s.password)
       z.delete_hosts_by_infra(self)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,6 +48,9 @@ class Project < ActiveRecord::Base
   end
 
   def detach_zabbix
+    if self.zabbix_server_id.nil?
+      return
+    end
     s = ZabbixServer.find(self.zabbix_server_id)
     # delete associated host and user group from Zabbix
     z = Zabbix.new(s.fqdn, s.username, s.password)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -58,6 +58,9 @@ class Project < ActiveRecord::Base
   end
 
   def register_hosts(zabbix, user)
+    if zabbix.nil?
+      return
+    end
     z = Zabbix.new(zabbix.fqdn, zabbix.username, zabbix.password)
     # add new hostgroup on zabbix with project code as its name
     if z.get_hostgroup_ids(self.code).empty?

--- a/app/models/server_state.rb
+++ b/app/models/server_state.rb
@@ -8,6 +8,11 @@
 
 class ServerState
   class NotRunning < StandardError; end
+  class InfrastructureNotFound < StandardError;
+    def status_code
+      404
+    end
+  end
 
   def initialize(kind)
     case kind
@@ -18,6 +23,7 @@ class ServerState
     else
       raise ArgumentError, "#{kind} is invalid as ServerStatus kind"
     end
+    raise InfrastructureNotFound if infra.nil?
 
     resources = infra.resources_or_create
     physical_id = resources.first.physical_id

--- a/app/views/app_settings/_panel_content_system.html.erb
+++ b/app/views/app_settings/_panel_content_system.html.erb
@@ -78,6 +78,13 @@
           <input type="text" class="form-control" id="subnet_id" name="subnet_id" placeholder="subnet-abcd1234 (optional)">
         </div>
       </div>
+
+      <div class="form-group">
+        <label for="skip_zabbix_server" class="col-sm-3 control-label"><%= t 'app_settings.skip_zabbix_server' %></label>
+        <div class="col-sm-7">
+          <input type="checkbox" class="form-control" id="skip_zabbix_server" name="skip_zabbix_server">
+        </div>
+      </div>
     </div>
 
   </fieldset>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -35,7 +35,7 @@
   <div class="form-group">
     <%= f.label :zabbix_server_id, t('projects.zabbix_servers'), class: 'control-label col-sm-2' %>
     <div class="col-sm-5">
-      <%= f.select :zabbix_server_id, @zabbix_servers.map{|x| [x.fqdn, x.id]}.unshift([t('common.none'), ""]), {class: "form-control"} %>
+      <%= f.select :zabbix_server_id, @zabbix_servers.map{|x| [x.fqdn, x.id]}.unshift([t('common.none'), ""]), {}, {class: "form-control"} %>
     </div>
   </div>
   <div class="form-group">

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -35,7 +35,7 @@
   <div class="form-group">
     <%= f.label :zabbix_server_id, t('projects.zabbix_servers'), class: 'control-label col-sm-2' %>
     <div class="col-sm-5">
-      <%= f.select :zabbix_server_id, @zabbix_servers.map{|x| [x.fqdn, x.id]}, {prompt: true}, {class: "form-control"} %>
+      <%= f.select :zabbix_server_id, @zabbix_servers.map{|x| [x.fqdn, x.id]}.unshift([t('common.none'), ""]), {class: "form-control"} %>
     </div>
   </div>
   <div class="form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
     please_select: 'Select one'
     not_set:       'Not set'
     selected:      'Selected'
+    none:           'None'
     btn:
       architecture:    'Architecture'
       settings:        'Settings'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
     chef_server:       'Chef Server'
     vpc_id:            'VPC ID'
     subnet_id:         'Subnet ID'
+    skip_zabbix_server: 'Not create Zabbix Server'
 
     msg:
       created:           'SkyHopper was successfully setup'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -581,6 +581,7 @@ en:
       download_chef:  'Downloading Chef Server packages...'
       install_chef:   'Installing Chef Server...'
       setting_chef:   'Setting up Chef Server...'
+      wait_for_zabbix_created: 'Waiting for completion of Zabbix Server creation...'
       complete:       'Chef Server was successfully constructed. Execute `cp -r ~/skyhopper/tmp/chef ~/.chef` and restart SkyHopper.'
       confirm_start:  'Do you want to start Chef Server?'
       confirm_stop:   'Do you want to stop Chef Server?'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -579,6 +579,7 @@ ja:
       download_chef:  'Chef Server のパッケージをダウンロードしています...'
       install_chef:   'Chef Server をインストールしています...'
       setting_chef:   'Chef Server を設定しています...'
+      wait_for_zabbix_created: 'Zabbix Server の作成完了を待っています...'
       complete:       'Chef Server の構築が完了しました. cp -r ~/skyhopper/tmp/chef ~/.chef を実行し、 SkyHopper を再起動してください。'
       confirm_start:  'Chef Server を起動しますか?'
       confirm_stop:   'Chef Server を停止しますか?'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,6 +32,7 @@ ja:
     please_select: '選択してください'
     not_set:       '設定なし'
     selected:      '選択されています'
+    none:           'なし'
     btn:
       architecture:    'インフラ管理'
       settings:        '設定'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -81,6 +81,7 @@ ja:
     chef_server:       'Chef Server'
     vpc_id:            'VPC ID'
     subnet_id:         'サブネット ID'
+    skip_zabbix_server: 'Zabbix Serverを作成しない'
 
     msg:
       created:           'アプリケーションは正常に設定されました'

--- a/spec/models/server_state_spec.rb
+++ b/spec/models/server_state_spec.rb
@@ -45,6 +45,16 @@ describe ServerState, type: :model do
       subject{ServerState.new('invalid as kind')}
       it {expect{subject}.to raise_error(ArgumentError)}
     end
+
+    context 'when infra not found' do
+      subject{ServerState.new('zabbix')}
+      before do
+        zabbix_server = Project.for_zabbix_server
+        zabbix_server.infrastructures = []
+        zabbix_server.save!
+      end
+      it {expect{subject}.to raise_error(ServerState::InfrastructureNotFound)}
+    end
   end
 
   let(:chef){ServerState.new('chef')}


### PR DESCRIPTION
アプリセットアップ時にZabbixServerを作成しないオプションを追加。
案件作成時のZabbixServerの選択肢になしを追加。
ZabbixServerがなくても動作するように変更。