### PR TITLE
ChefServerが起動していなくても最低限の機能を使えるようにする

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -98,6 +98,7 @@ class NodesController < ApplicationController
     @chef_server_not_running = false
     if !chef_server.is_running?
       @chef_server_not_running = true
+      @runlist_error_message = I18n.t('chef_servers.msg.not_running')
       return
     end
 

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -23,6 +23,7 @@ class NodesController < ApplicationController
     @locale = I18n.locale
   end
 
+  before_action :check_chef_server_running, only: [:edit, :recipes, :update, :edit_attributes, :update_attributes, :cook]
 
 
   # GET /nodes/:id/run_bootstrap
@@ -465,5 +466,10 @@ class NodesController < ApplicationController
 
   def set_infra
     @infra = Infrastructure.find(params.require(:infra_id))
+  end
+
+  def check_chef_server_running
+    chef_server = ServerState.new('chef')
+    chef_server.should_be_running!(I18n.t('chef_servers.msg.not_running'))
   end
 end

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -23,7 +23,7 @@ class NodesController < ApplicationController
     @locale = I18n.locale
   end
 
-  before_action :check_chef_server_running, only: [:edit, :recipes, :update, :edit_attributes, :update_attributes, :cook, :apply_dish]
+  before_action :check_chef_server_running, only: [:run_bootstrap, :edit, :recipes, :update, :edit_attributes, :update_attributes, :cook, :apply_dish]
 
 
   # GET /nodes/:id/run_bootstrap

--- a/app/views/nodes/show.jbuilder
+++ b/app/views/nodes/show.jbuilder
@@ -10,10 +10,9 @@ json.availability_zone @instance_summary[:availability_zone]
 json.chef_error @chef_error
 json.chef_msg   @chef_msg
 json.before_bootstrap @before_bootstrap
-json.chef_server_not_running @chef_server_not_running
 
 json.runlist       @runlist
-json.runlist_error_message       @runlist_error_message
+json.runlist_error       @runlist_error
 json.selected_dish @selected_dish
 json.dishes        @dishes
 json.attribute_set @attribute_set

--- a/app/views/nodes/show.jbuilder
+++ b/app/views/nodes/show.jbuilder
@@ -10,6 +10,7 @@ json.availability_zone @instance_summary[:availability_zone]
 json.chef_error @chef_error
 json.chef_msg   @chef_msg
 json.before_bootstrap @before_bootstrap
+json.chef_server_not_running @chef_server_not_running
 
 json.runlist       @runlist
 json.selected_dish @selected_dish

--- a/app/views/nodes/show.jbuilder
+++ b/app/views/nodes/show.jbuilder
@@ -13,6 +13,7 @@ json.before_bootstrap @before_bootstrap
 json.chef_server_not_running @chef_server_not_running
 
 json.runlist       @runlist
+json.runlist_error_message       @runlist_error_message
 json.selected_dish @selected_dish
 json.dishes        @dishes
 json.attribute_set @attribute_set

--- a/app/views/vue/_ec2_tabpane.html.erb
+++ b/app/views/vue/_ec2_tabpane.html.erb
@@ -265,7 +265,7 @@
   <%# Runlist table %>
   <div class="col-xs-12 col-sm-10">
     <h5 class="page-header">Runlist</h5>
-    <table class="table table-condensed">
+    <table v-if="!ec2.chef_server_not_running" class="table table-condensed">
       <thead>
         <tr>
           <th>type</th>
@@ -284,6 +284,7 @@
         </tr>
       </tbody>
     </table>
+    <p v-if="ec2.chef_server_not_running" v-text="ec2.runlist_error_message"></p>
   </div>
 
   <%# Buttons %>

--- a/app/views/vue/_ec2_tabpane.html.erb
+++ b/app/views/vue/_ec2_tabpane.html.erb
@@ -293,7 +293,7 @@
         <button @click="cook({whyrun: true})" :disabled="!ec2.attribute_set" class="btn btn-sm btn-primary">
           <%= t 'nodes.cook_in_why_run_mode'%>
         </button>
-        <button type="button" :disabled="!ec2.attribute_set" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button type="button" :disabled="ec2.chef_server_not_running || !ec2.attribute_set" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span class="caret"></span>
           <span class="sr-only">Toggle Dropdown</span>
         </button>
@@ -301,8 +301,8 @@
           <li><a @click="cook({whyrun: false})" href="#"><%= t 'nodes.cook' %></a></li>
         </ul>
       </div>
-      <button @click="edit_runlist()" class="btn btn-default btn-sm"><%= t 'nodes.btn.edit_runlist' %></button>
-      <button @click="edit_attr()" class="btn btn-sm btn-default" :class="{'border-blink': !ec2.attribute_set}"><%= t 'nodes.btn.instance_settings' %></button>
+      <button :disabled="ec2.chef_server_not_running" @click="edit_runlist()" class="btn btn-default btn-sm"><%= t 'nodes.btn.edit_runlist' %></button>
+      <button :disabled="ec2.chef_server_not_running" @click="edit_attr()" class="btn btn-sm btn-default" :class="{'border-blink': !ec2.chef_server_not_running && !ec2.attribute_set}"><%= t 'nodes.btn.instance_settings' %></button>
       <div class="dropup" style="display: inline-block" v-if="!ec2.platform">
         <button class="btn btn-sm btn-warning dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-expanded="true">
           yum

--- a/app/views/vue/_ec2_tabpane.html.erb
+++ b/app/views/vue/_ec2_tabpane.html.erb
@@ -235,7 +235,7 @@
 </div>
 
 <%# show-node-infomation %>
-<div v-if="!ec2.chef_error && !ec2.before_bootstrap && running">
+<div v-if="running">
   <h4 class="page-header col-xs-12"><%= t 'ec2_instances.settings' %></h4>
 
   <%# Status labels %>
@@ -265,7 +265,7 @@
   <%# Runlist table %>
   <div class="col-xs-12 col-sm-10">
     <h5 class="page-header">Runlist</h5>
-    <table v-if="!ec2.chef_server_not_running" class="table table-condensed">
+    <table v-if="!ec2.runlist_error" class="table table-condensed">
       <thead>
         <tr>
           <th>type</th>
@@ -284,7 +284,7 @@
         </tr>
       </tbody>
     </table>
-    <p v-if="ec2.chef_server_not_running" v-text="ec2.runlist_error_message"></p>
+    <p v-if="ec2.runlist_error"><%= t('infrastructures.failed_to_get_runlist') %></p>
   </div>
 
   <%# Buttons %>
@@ -294,7 +294,7 @@
         <button @click="cook({whyrun: true})" :disabled="!ec2.attribute_set" class="btn btn-sm btn-primary">
           <%= t 'nodes.cook_in_why_run_mode'%>
         </button>
-        <button type="button" :disabled="ec2.chef_server_not_running || !ec2.attribute_set" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button type="button" :disabled="ec2.chef_error || ec2.before_bootstrap || !ec2.attribute_set" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span class="caret"></span>
           <span class="sr-only">Toggle Dropdown</span>
         </button>
@@ -302,8 +302,8 @@
           <li><a @click="cook({whyrun: false})" href="#"><%= t 'nodes.cook' %></a></li>
         </ul>
       </div>
-      <button :disabled="ec2.chef_server_not_running" @click="edit_runlist()" class="btn btn-default btn-sm"><%= t 'nodes.btn.edit_runlist' %></button>
-      <button :disabled="ec2.chef_server_not_running" @click="edit_attr()" class="btn btn-sm btn-default" :class="{'border-blink': !ec2.chef_server_not_running && !ec2.attribute_set}"><%= t 'nodes.btn.instance_settings' %></button>
+      <button :disabled="ec2.chef_error || ec2.before_bootstrap" @click="edit_runlist()" class="btn btn-default btn-sm"><%= t 'nodes.btn.edit_runlist' %></button>
+      <button :disabled="ec2.chef_error || ec2.before_bootstrap" @click="edit_attr()" class="btn btn-sm btn-default" :class="{'border-blink': !ec2.chef_error  && !ec2.before_bootstrap && !ec2.attribute_set}"><%= t 'nodes.btn.instance_settings' %></button>
       <div class="dropup" style="display: inline-block" v-if="!ec2.platform">
         <button class="btn btn-sm btn-warning dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-expanded="true">
           yum

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
     in_progress:        'In progress...'
     database:           'Database'
     runlist:            'Runlist'
+    failed_to_get_runlist: 'Failed to get Runlist'
     instance_type:      'Instance type'
     add_ec2:            'Add EC2'
     serverspec_failed:  'Serverspec failed'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -178,6 +178,7 @@ ja:
     in_progress:        '実行中...'
     database:           'データベース'
     runlist:            'Runlist'
+    failed_to_get_runlist: 'Runlistの取得に失敗しました'
     instance_type:      'インスタンスの種類'
     add_ec2:            'EC2の追加'
     serverspec_failed:  'Serverspec が失敗しています'

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -13,6 +13,10 @@ describe NodesController, type: :controller do
   let(:infra){create(:infrastructure)}
   let(:physical_id){attributes_for(:resource)[:physical_id]}
 
+  before do
+    allow(controller).to receive(:check_chef_server_running).and_return(nil)
+  end
+
   describe '#run_bootstrap' do
     let(:req){get :run_bootstrap, id: physical_id, infra_id: infra.id}
     let(:fqdn){'sky.example.com'}


### PR DESCRIPTION
ChefServerが起動していなくても最低限の機能を使えるようにしました。
なお、今現在Dish周りの機能が動作しないためそちらは未改修となります。