### PR TITLE
SkyHopperをVersion2にアップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [English Readme](README_EN.md)
 
 ## Notice
-Version2から、ChefはAnsibleに置き換えられます。  
+SkyHopper Version2から、ChefはAnsibleに置き換えられます。  
 Chefの機能の一部はまだ使える状態ですが、将来的には削除される予定です。
 
 ## blog

--- a/README.md
+++ b/README.md
@@ -3,30 +3,23 @@
 
 [English Readme](README_EN.md)
 
+## Notice
+Version2から、ChefはAnsibleに置き換えられます。  
+Chefの機能の一部はまだ使える状態ですが、将来的には削除される予定です。
+
 ## blog
+以下のリンク先の情報はVersion1のものです。  
 http://www.skyarch.net/blog/?p=2709
 
 RSpec: [![Build Status](https://travis-ci.org/skyarch-networks/skyhopper.svg?branch=master)](https://travis-ci.org/skyarch-networks/skyhopper)
 
 ## デプロイ手順フロー
+Chefの機能に一部の処理が依存していため、Chefのインストールが必要です。
+Chefの機能は将来的に削除される予定です。
 
 ### アプリケーションのデプロイ
 
 [doc/installation/skyhopper.md](doc/installation/skyhopper.md)
-
-1. rubyのインストール
-1. node.jsのインストール
-1. SkyHopperに必要なパッケージをインストール
-1. リバースプロキシの設定
-1. サービスの起動
-1. SkyHopperのダウンロード
-1. MySQLのセットアップ
-1. SkyHopperのセットアップ
-1. DBのセットアップ
-1. パーミッションの設定
-1. SkyHopperの初期設定
-1. Chef Serverの鍵を設置
-
 
 ### Cookbook/Roleのアップロード
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Chefの機能は将来的に削除される予定です。
 [doc/installation/zabbix_server.md](doc/installation/zabbix_server.md)
 
 
+### Ansible
+`<project-root>/ansible/roles`配下にお好きなAnsibleロールを配置してください。
+
 ### アップデート手順
 
 最新のリリースページを参考にしてください。

--- a/README_EN.md
+++ b/README_EN.md
@@ -31,6 +31,9 @@ The function of Chef will be removed in the future.
 [doc/installation/zabbix_server.md](doc/installation/en/zabbix_server.md)
 
 
+### Ansible
+Lease place your favorite Ansible role under `<project-root>/ansible/roles`.
+
 ### Update procedure
 
 Please refer to the latest release page for reference.

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@ A Tool for Automatic Construction of Systems (IaaS/ Infrastructure as Code)
 [日本語ドキュメント](README.md)
 
 ## Notice
-From Version 2, Chef is replaced by Ansible.  
+From SkyHopper Version 2, Chef is replaced by Ansible.  
 Some features of Chef are still available but will be removed in the future.
 
 ## blog

--- a/README_EN.md
+++ b/README_EN.md
@@ -3,30 +3,23 @@ A Tool for Automatic Construction of Systems (IaaS/ Infrastructure as Code)
 
 [日本語ドキュメント](README.md)
 
+## Notice
+From Version 2, Chef is replaced by Ansible.  
+Some features of Chef are still available but will be removed in the future.
+
 ## blog
+The information on the following link destination is for Version 1.  
 http://www.skyarch.net/blog/?p=2709
 
 RSpec: [![Build Status](https://travis-ci.org/skyarch-networks/skyhopper.svg?branch=master)](https://travis-ci.org/skyarch-networks/skyhopper)
 
 ## Deployment steps
+Since some processing depends on the function of Chef, installation of Chef is necessary.  
+The function of Chef will be removed in the future.
 
 ### Deploying Applications
 
 [doc/installation/en/skyhopper.md](doc/installation/en/skyhopper.md)
-
-1. Installation of Ruby
-1. Installation of Node.js
-1. Installing the necessary packages for SkyHopper
-1. Setting up a reverse proxy
-1. Starting of Services
-1. Downloading/Cloning SkyHopper from GitHub
-1. MySQL Setup
-1. SkyHopper Setup
-1. Database Setup
-1. Setting permissions
-1. Initializing settings for SkyHopper
-1. And establishing the Chef Server keys
-
 
 ### Cookbook / Role Upload
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,7 @@ module SkyHopper
     config.active_job.queue_adapter = :sidekiq
 
     # Version information
-    config.my_version = 'Version 1.25.0'
+    config.my_version = 'Version 2.0.0'
 
     config.browserify_rails.paths << /frontend\//
   end

--- a/doc/installation/en/skyhopper.md
+++ b/doc/installation/en/skyhopper.md
@@ -1,10 +1,5 @@
 # SkyHopper deployment procedure
 
-By using [SkyHopper Cookbooks](https://github.com/skyarch-networks/skyhopper_cookbooks/tree/master/cookbooks/skyhopper), you can automate your system by installing a package.
-
-If you used cookbook, we will proceed to [Creating MySQL user](#user-content-creating-mysql-user).
-
-
 ## Prefered OS
 
 Amazon Linux (RHEL System)
@@ -162,12 +157,6 @@ $ sudo service nginx start
 $ cd ~ #the directory where you want to install SkyHopper
 $ git clone https://github.com/skyarch-networks/skyhopper.git
 ```
-
-
-
-Up to this point it can be executed by Chef.
-
----------------------------------
 
 ### Creating MySQL user
 

--- a/doc/installation/skyhopper.md
+++ b/doc/installation/skyhopper.md
@@ -1,11 +1,5 @@
 # SkyHopper デプロイ手順
 
-[SkyHopper 用の Cookbook](https://github.com/skyarch-networks/skyhopper_cookbooks/tree/master/cookbooks/skyhopper)
-を使用することで、パッケージのインストールなどを自動化することが出来ます。
-
-Cookbook を使用した場合は、[MySQL ユーザーの作成](#user-content-mysql-ユーザーの作成) から実行していきます。
-
-
 ## 対象
 
 Amazon Linux (RHEL系)
@@ -163,11 +157,6 @@ $ sudo service nginx start
 $ cd ~ #SkyHopperを設置したいディレクトリへ移動
 $ git clone https://github.com/skyarch-networks/skyhopper.git
 ```
-
-
-ここまでは Chef によって実行することが出来ます。
-
----------------------------------
 
 ### MySQL ユーザーの作成
 


### PR DESCRIPTION
SkyHopperのVersionを2に上げます。
Version2では、Chefの機能は削除され、Ansibleに置き換えられます。
Chefの機能の一部はまだ使える状態ですが、将来的には削除される予定です。