### PR TITLE
ZabbixServerインストール時に非推奨のオプションを使用していたのを修正

### DIFF
--- a/lib/erb-builder/templates/zabbix_server.json.erb
+++ b/lib/erb-builder/templates/zabbix_server.json.erb
@@ -92,7 +92,7 @@
           "#! /bin/bash -v\n",
           "cd ~\n",
           "rpm -Uvh https://packages.chef.io/files/stable/chef/12.22.5/el/6/chef-12.22.5-1.el6.x86_64.rpm\n",
-          "/opt/chef/embedded/bin/gem install knife-solo --no-ri --no-rdoc\n",
+          "/opt/chef/embedded/bin/gem install knife-solo --no-document\n",
           "yum install -y git\n",
           "git clone https://github.com/skyarch-networks/skyhopper_cookbooks.git\n",
           "cd skyhopper_cookbooks/install_zabbix_server/\n",


### PR DESCRIPTION
ZabbixServerインストール時に非推奨のオプションを使用していたのを修正しました。