### PR TITLE
インスタストラクチャの詳細画面の不具合を修正

### DIFF
--- a/app/assets/javascripts/modules/newVM.js
+++ b/app/assets/javascripts/modules/newVM.js
@@ -268,6 +268,7 @@ module.exports = function () {
                   self.show_s3(physical_id);
                 }
               } else {
+                self.tabpaneID = 'default';
                 self.show_no_resource();
               }
             }


### PR DESCRIPTION
インスタストラクチャ一覧画面で、「リソース有りのインフラ」→「リソース無しのインフラ」の順番に表示した場合に画面の表示がおかしい不具合の修正