### PR TITLE
dockerでの起動の高速化

### DIFF
--- a/docker-compose.override-mac-sample.yml
+++ b/docker-compose.override-mac-sample.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  app:
+    volumes:
+      - ".:/prj/skyhopper:cached"
+      - "./amazonlinux2/known_hosts:/root/.ssh/known_hosts:cached"
+
+  nginx:
+    volumes:
+      - "./nginx/conf.d:/etc/nginx/conf.d:cached"
+      - ".:/prj/skyhopper:cached"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - ".:/prj/skyhopper:cached"
       - "./amazonlinux2/known_hosts:/root/.ssh/known_hosts:cached"
+      # exclude
+      - /prj/skyhopper/.git
     environment:
       - REDIS_HOST=redis
       - REDIS_URL=redis://redis:6379/1
@@ -41,5 +43,7 @@ services:
     volumes:
       - "./nginx/conf.d:/etc/nginx/conf.d:cached"
       - ".:/prj/skyhopper:cached"
+      # exclude
+      - /prj/skyhopper/.git
     depends_on:
       - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: ./amazonlinux2
       dockerfile: ./Dockerfile
     volumes:
-      - ".:/prj/skyhopper"
-      - "./amazonlinux2/known_hosts:/root/.ssh/known_hosts"
+      - ".:/prj/skyhopper:cached"
+      - "./amazonlinux2/known_hosts:/root/.ssh/known_hosts:cached"
     environment:
       - REDIS_HOST=redis
       - REDIS_URL=redis://redis:6379/1
@@ -21,7 +21,7 @@ services:
   mysql:
     image: mysql:5.7
     volumes:
-      - "./mysql:/var/lib/mysql"
+      - "./mysql:/var/lib/mysql:cached"
     environment:
       - MYSQL_ROOT_PASSWORD=password
     ports:
@@ -39,7 +39,7 @@ services:
     ports:
       - 80:80
     volumes:
-      - "./nginx/conf.d:/etc/nginx/conf.d"
-      - ".:/prj/skyhopper"
+      - "./nginx/conf.d:/etc/nginx/conf.d:cached"
+      - ".:/prj/skyhopper:cached"
     depends_on:
       - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: ./amazonlinux2
       dockerfile: ./Dockerfile
     volumes:
-      - ".:/prj/skyhopper:cached"
-      - "./amazonlinux2/known_hosts:/root/.ssh/known_hosts:cached"
+      - ".:/prj/skyhopper"
+      - "./amazonlinux2/known_hosts:/root/.ssh/known_hosts"
       # exclude
       - /prj/skyhopper/.git
     environment:
@@ -23,7 +23,7 @@ services:
   mysql:
     image: mysql:5.7
     volumes:
-      - "./mysql:/var/lib/mysql:cached"
+      - "./mysql:/var/lib/mysql"
     environment:
       - MYSQL_ROOT_PASSWORD=password
     ports:
@@ -41,8 +41,8 @@ services:
     ports:
       - 80:80
     volumes:
-      - "./nginx/conf.d:/etc/nginx/conf.d:cached"
-      - ".:/prj/skyhopper:cached"
+      - "./nginx/conf.d:/etc/nginx/conf.d"
+      - ".:/prj/skyhopper"
       # exclude
       - /prj/skyhopper/.git
     depends_on:


### PR DESCRIPTION
Docker for macでVolumeのマウントが遅いのでキャッシュを有効にした