### PR TITLE
インフラストラクチャのELBタブでセキュリティグループのNameが表示されない不具合の修正

### DIFF
--- a/app/assets/javascripts/infrastructures/elb-tabpane.js
+++ b/app/assets/javascripts/infrastructures/elb-tabpane.js
@@ -254,7 +254,7 @@ module.exports = Vue.extend({
       }
     },
     check_tag(r) {
-      check_tag(r);
+      return check_tag(r);
     },
     showPrev() {
       if (this.isStartPage) return;


### PR DESCRIPTION
インフラストラクチャのELBタブでセキュリティグループのNameが表示されない不具合を修正しました。