### PR TITLE
EC2周りの通信の修正とセキュリティグループ周りの修正

### DIFF
--- a/app/assets/javascripts/infrastructures/view-rules-tabpane.js
+++ b/app/assets/javascripts/infrastructures/view-rules-tabpane.js
@@ -83,7 +83,7 @@ module.exports = Vue.extend({
               record.push({ text: rule.ip_permissions_egress[i].prefix_list_ids, row: 1 });
               record.push({ text: rule.ip_permissions_egress[i].ip_protocol, row: 1 });
               record.push({ text: rule.ip_permissions_egress[i].to_port, row: 1 });
-              record.push({ text: rule.ip_permissions_egress[i].ip_ranges[0].cidr_ip, row: 1 });
+              record.push({ text: rule.ip_permissions_egress[i].ip_ranges.map(x => x.cidr_ip).join(', '), row: 1 });
             } else {
               record.push({ text: '', row: 1 });
               record.push({ text: '', row: 1 });

--- a/app/assets/javascripts/models/ec2_instance.js
+++ b/app/assets/javascripts/models/ec2_instance.js
@@ -171,7 +171,7 @@ const EC2Instance = class EC2Instance extends ModelBase {
 
   apply_dish(dishId) {
     const self = this;
-    const params = Object.assign({}, this.params, dishId ? { dishId } : {});
+    const params = Object.assign({}, this.params, dishId ? { dish_id: dishId } : {});
     return this.WrapAndResolveReject(
       () => self.ajax_node.apply_dish(params),
     );
@@ -179,7 +179,7 @@ const EC2Instance = class EC2Instance extends ModelBase {
 
   submit_groups(groupIds) {
     const self = this;
-    const params = Object.assign({}, this.params, groupIds ? { groupIds } : {});
+    const params = Object.assign({}, this.params, groupIds ? { group_ids: groupIds } : {});
     return this.WrapAndResolveReject(
       () => self.ajax_node.submit_groups(params),
     );
@@ -187,7 +187,7 @@ const EC2Instance = class EC2Instance extends ModelBase {
 
   create_group(groupParams) {
     const self = this;
-    const params = Object.assign({}, this.params, groupParams ? { groupParams } : {});
+    const params = Object.assign({}, this.params, groupParams ? { group_params: groupParams } : {});
     return this.WrapAndResolveReject(
       () => self.ajax_node.create_group(params),
     );
@@ -195,7 +195,7 @@ const EC2Instance = class EC2Instance extends ModelBase {
 
   get_rules(groupIds) {
     const self = this;
-    const params = Object.assign({}, this.params, groupIds ? { groupIds } : []);
+    const params = Object.assign({}, this.params, groupIds ? { group_ids: groupIds } : []);
     return this.WrapAndResolveReject(
       () => self.ajax_node.get_rules(params),
     );


### PR DESCRIPTION
EC2周りの通信で、パラメータが正常に送信されていなかった不具合を修正しました。
インフラストラクチャのセキュリティグループを表示する画面で、セキュリティグループの表が表示されない不具合を修正しました。