### PR TITLE
Travis上でのビルド環境の変更によるエラーの一時的な修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: ruby
 
 rvm:


### PR DESCRIPTION
Ubuntu14.04を明示的に使用するようにすることでエラーを回避する
14.04がEOLなので16.04で起こるエラーの修正ができ次第14.04の指定を消したほうがいいと思われます