### PR TITLE
ユーザー管理機能の修正

### DIFF
--- a/app/assets/javascripts/user_index.js
+++ b/app/assets/javascripts/user_index.js
@@ -39,17 +39,14 @@ const demoGrid = require('./demo-grid.js');
         },
 
         delete_entry() {
-          const self = this;
-          modal.Confirm(t('users.user'), t('users.msg.delete_user', self.email), 'danger').done(() => {
+          modal.Confirm(t('users.user'), t('users.msg.delete_user', this.email), 'danger').done(() => {
             $.ajax({
               type: 'POST',
-              url: self.picked.users_admin_path,
+              url: this.picked.users_admin_path,
               dataType: 'json',
               data: { _method: 'delete' },
-              success(data) {
-                self.gridData = data;
-                self.picked = {};
-              },
+            }).done(() => {
+              window.location.reload();
             }).fail(() => {
               window.location.reload();
             });

--- a/app/controllers/users_admin_controller.rb
+++ b/app/controllers/users_admin_controller.rb
@@ -191,7 +191,7 @@ class UsersAdminController < ApplicationController
     # delete user from SkyHopper
     @user.destroy
 
-    ws_send(t('users.msg.deleted', name: @user.email), true)
+    flash[:notice] = t('users.msg.deleted', name: @user.email)
     redirect_to(action: :index)
   end
 

--- a/app/controllers/users_admin_controller.rb
+++ b/app/controllers/users_admin_controller.rb
@@ -177,9 +177,8 @@ class UsersAdminController < ApplicationController
     end
 
     # delete user from zabbix
-    servers = ZabbixServer.all
     begin
-      servers.each do |s|
+      @user.zabbix_servers.each do |s|
         z = Zabbix.new(s.fqdn, current_user.email, current_user.encrypted_password)
         z.delete_user(@user.email)
       end

--- a/app/controllers/users_admin_controller.rb
+++ b/app/controllers/users_admin_controller.rb
@@ -170,6 +170,12 @@ class UsersAdminController < ApplicationController
   # DELETE /users_admin/1
   def destroy
     @user = User.find(params.require(:id))
+
+    if @user == current_user
+      flash[:alert] = t('users.msg.cannot_delete_yourself')
+      raise 'Cannot delete yourself'
+    end
+
     # delete user from zabbix
     servers = ZabbixServer.all
     begin

--- a/app/views/users_admin/new.html.erb
+++ b/app/views/users_admin/new.html.erb
@@ -37,7 +37,7 @@
   <div class="form-group">
     <%= f.label t('zabbix_servers.zabbix'), class: 'col-sm-2 control-label' %>
     <div class="col-sm-5">
-      <%= f.select(:zabbix_servers, options_from_collection_for_select(@zabbix_servers, 'id', 'fqdn'), {}, {:multiple => true, :size => 10, :required => true}) %>
+      <%= f.select(:zabbix_servers, options_from_collection_for_select(@zabbix_servers, 'id', 'fqdn'), {}, {:multiple => true, :size => 10}) %>
     </div>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -579,6 +579,7 @@ en:
       use_stop_mfa:          'If save changes, use stop MFA.'
       delete_user:           'Are you sure you want to delete this User?'
       error:                 'An error occured while processing Zabbix: "%{msg}"'
+      cannot_delete_yourself: 'Cannot delete yourself'
 
 
   system_servers:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -576,6 +576,7 @@ ja:
       use_stop_mfa:          '変更を保存すると、MFA の使用を停止します。'
       delete_user:           'このユーザーを削除してもよろしいですか？'
       error:                 'Zabbix 処理中にエラーが発生しました "%{msg}"'
+      cannot_delete_yourself: '自分自身を削除することはできません'
 
 
   system_servers:


### PR DESCRIPTION
ユーザー作成時のZabbixサーバの選択を任意に変更しました。
ユーザー削除時に自分自身を削除しようとしたときにエラーメッセージを追加しました。
ユーザー削除時のZabbixサーバに対する処理がおかしい不具合を修正しました。