### PR TITLE
インストール手順でnodeのバージョンを固定

### DIFF
--- a/doc/installation/en/skyhopper.md
+++ b/doc/installation/en/skyhopper.md
@@ -28,11 +28,11 @@ $ sudo gem install bundler
 ```sh
 $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash
 $ . ~/.nvm/nvm.sh
-$ nvm install stable
+$ nvm install --lts=dubnium
 # update npm to lastest version
 $ npm update -g npm
 $ node -v
-v10.12.0 # any current stable version release
+v10.X.X # any current stable version release
 ```
 
 ## Installing Yarn

--- a/doc/installation/skyhopper.md
+++ b/doc/installation/skyhopper.md
@@ -28,11 +28,11 @@ $ sudo gem install bundler
 ```sh
 $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.0/install.sh | bash
 $ . ~/.nvm/nvm.sh
-$ nvm install stable
+$ nvm install --lts=dubnium
 # update npm to lastest version
 $ npm update -g npm
 $ node -v
-v10.12.0 # any current stable version release
+v10.X.X # any current stable version release
 ```
 
 ## Yarn のインストール


### PR DESCRIPTION
jquery-uiのビルドに必要なため、インストール手順でnodeのバージョンを固定しました。