### PR TITLE
DBのエクスポートに非互換性オプションを追加

### DIFF
--- a/app/controllers/databases_controller.rb
+++ b/app/controllers/databases_controller.rb
@@ -25,8 +25,10 @@ class DatabasesController < ApplicationController
   def export
     authenticate_user!
 
+    no_compatibility = params[:no_compatibility].present?
+
     time = Time.zone.now.strftime('%Y%m%d%H%M%S')
-    zipfile = DatabaseManager.export_as_zip
+    zipfile = DatabaseManager.export_as_zip(no_compatibility: no_compatibility)
     send_file(zipfile.path, filename: "SkyHopper-db-#{Rails.env}-#{time}.zip")
     zipfile.close
   end

--- a/app/models/database_manager.rb
+++ b/app/models/database_manager.rb
@@ -16,12 +16,16 @@ class DatabaseManager
   }.freeze
 
   class << self
-    def export_as_zip
+    def export_as_zip(no_compatibility: false)
       dbname   = ActiveRecord::Base.configurations[Rails.env]['database']
       filename = "#{dbname}.sql"
       path     = Rails.root.join("tmp/#{filename}")
 
-      system('rails db:data:dump')
+      if no_compatibility
+        system('rails db:data:dump[,modern]')
+      else
+        system('rails db:data:dump[,legacy]')
+      end
 
       zipfile = Tempfile.open('skyhopper')
       ::Zip::File.open(zipfile.path, ::Zip::File::CREATE) do |zip|

--- a/app/views/databases/_modal_export.html.erb
+++ b/app/views/databases/_modal_export.html.erb
@@ -23,6 +23,12 @@
         </div>
         <form action="<%= export_database_path %>" method="POST">
           <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" >
+          <div class="form-group">
+            <label for="no_compatibility" class="col-sm-11 control-label"><%= t('databases.msg.no_compatibility') %></label>
+            <div class="col-sm-1">
+              <input type="checkbox" name="no_compatibility" value="yes">
+            </div>
+          </div>
           <button type="submit" class="btn btn-primary btn-lg btn-block" :disabled="loading" @click="">
             <div-loader v-if="loading"></div-loader>
             <span v-if="!loading">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -761,6 +761,7 @@ en:
       secret:    'secret_key_base'
       db_key:    'db_crypt_key'
       db_salt:    'db_crypt_salt'
+      no_compatibility: 'Not keep compatibility'
       db_export: 'When exporting SkyHopper Database into a zip file, the following files are included: '
       db_import: 'When importing SkyHopper Database, select a zip file that contains these files: '
       db_import_finish: 'Database import has finished.'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -758,6 +758,7 @@ ja:
       secret:    'secret_key_base'
       db_key:    'db_crypt_key'
       db_salt:    'db_crypt_salt'
+      no_compatibility: '互換性を維持しない'
       db_export: 'エクスポートしたZIPファイルには下記のファイルが含まれています。'
       db_import: 'DB をインポートするには下記のファイルを含む ZIP ファイルを指定してください'
       db_import_finish: 'データベースのインポートが完了しました'


### PR DESCRIPTION
DBのエクスポートに非互換性オプションを追加しました。
DBのエクスポート時に、”互換性を維持しない”にチェックを入れてエクスポートすると、mysqldump時の `--compatible=ansi` の指定が解除されます。
”互換性を維持しない”のチェックを外してエクスポートすると、今までと同じ挙動になります。