### PR TITLE
known_hostsファイルの管理方法の変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ config/database.yml
 
 # Docker
 /docker-compose.override.yml
-/amazonlinux2/known_hosts
+/amazonlinux2/.ssh/
 /mysql/
 /redis/
 /phpmyadmin/

--- a/app/assets/javascripts/infrastructures/ec2-tabpane.js
+++ b/app/assets/javascripts/infrastructures/ec2-tabpane.js
@@ -191,6 +191,15 @@ module.exports = Vue.extend({
       });
     },
 
+    register_for_known_hosts() {
+      const infra = new Infrastructure(this.infra_id);
+      const ec2 = new EC2Instance(infra, this.physical_id);
+
+      ec2.register_for_known_hosts()
+        .done(alertSuccess(this._show_ec2))
+        .fail(alertDanger(this._show_ec2));
+    },
+
     apply_dish() {
       const infra = new Infrastructure(this.infra_id);
       const ec2 = new EC2Instance(infra, this.physical_id);

--- a/app/assets/javascripts/models/ec2_instance.js
+++ b/app/assets/javascripts/models/ec2_instance.js
@@ -16,6 +16,7 @@ const EC2Instance = class EC2Instance extends ModelBase {
     this.ajax_node.add_member('run_bootstrap', 'GET');
     this.ajax_node.add_member('get_rules', 'GET');
     this.ajax_node.add_member('get_security_groups', 'GET');
+    this.ajax_node.add_member('register_for_known_hosts', 'POST');
     this.ajax_node.add_member('apply_dish', 'POST');
     this.ajax_node.add_member('submit_groups', 'POST');
     this.ajax_node.add_member('edit_attributes', 'GET');
@@ -141,6 +142,12 @@ const EC2Instance = class EC2Instance extends ModelBase {
     };
     const params = Object.assign({}, this.params, extraParams);
     return this._cook('yum_update', params);
+  }
+
+  register_for_known_hosts() {
+    return this.WrapAndResolveReject(
+      () => this.ajax_node.register_for_known_hosts(this.params),
+    );
   }
 
   edit_ansible_playbook() {

--- a/app/controllers/cf_templates_controller.rb
+++ b/app/controllers/cf_templates_controller.rb
@@ -207,46 +207,11 @@ class CfTemplatesController < ApplicationController
     infrastructure.status = stack.status[:message]
     infrastructure.save!
 
-    add_keys_in_known_hosts(infrastructure)
-
     cf_template.update_cfparams
 
     cf_template.save!
 
     infra_logger_success("#{action} stack is being started.", infrastructure_id: infrastructure.id)
     { message: t("cf_templates.msg.#{action.downcase}"), status: true }
-  end
-
-  def add_keys_in_known_hosts(infrastructure)
-    Thread.new_with_db do
-      begin
-        Rails.logger.info("[add_keys_in_known_hosts] Add keys in known_hosts is started. infra_id: #{infrastructure.id}")
-
-        stack = Stack.new(infrastructure)
-
-        Rails.logger.info("[add_keys_in_known_hosts] Waiting creat complate or update complete. stack_name: #{stack.name}")
-        stack.wait_creat_complate_or_update_complete
-
-        infrastructure.resources.destroy_all
-        infrastructure.save!
-        infrastructure.reload
-        resources = infrastructure.resources_or_create
-
-        ec2_resources = resources.ec2
-        ec2_resources.each do |ec2_resource|
-          instance = infrastructure.instance(ec2_resource.physical_id)
-          instance.wait_status(:running)
-          instance.wait_status_check_ok
-          instance.register_in_known_hosts(tries: 12, sleep: 5)
-          ec2_resource.register_in_known_hosts = true
-          ec2_resource.save!
-        end
-      rescue StandardError => ex
-        Rails.logger.error("[add_keys_in_known_hosts] Add keys in known_hosts is failed. infra_id: #{infrastructure.id}")
-        Rails.logger.error ex
-      else
-        Rails.logger.info("[add_keys_in_known_hosts] Add keys in known_hosts is finished. infra_id: #{infrastructure.id}")
-      end
-    end
   end
 end

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -243,7 +243,7 @@ class NodesController < ApplicationController
   def register_for_known_hosts
     ec2_instance = @infra.instance(@physical_id)
 
-    ec2_instance.register_in_known_hosts(update: true)
+    ec2_instance.register_in_known_hosts
 
     render plain: I18n.t('nodes.msg.registered_in_known_hosts') and return
   end
@@ -351,8 +351,8 @@ class NodesController < ApplicationController
 
   def check_register_in_knwon_hosts
     physical_id = params.require(:id)
-    ec2_instance = @infra.instance(physical_id)
+    resource = @infra.resource(physical_id)
 
-    raise I18n.t('nodes.msg.not_register_in_known_hosts') unless ec2_instance.registered_in_known_hosts?
+    resource.should_be_registered_in_known_hosts(I18n.t('nodes.msg.not_register_in_known_hosts'))
   end
 end

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -341,6 +341,8 @@ class NodesController < ApplicationController
 
   def check_register_in_knwon_hosts
     physical_id = params.require(:id)
-    @infra.resource(physical_id).should_be_registered_in_known_hosts(I18n.t('nodes.msg.not_register_in_known_hosts'))
+    ec2_instance = @infra.instance(physical_id)
+
+    raise I18n.t('nodes.msg.not_register_in_known_hosts') unless ec2_instance.registered_in_known_hosts?
   end
 end

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -239,7 +239,7 @@ class NodesController < ApplicationController
     render plain: ret[:message], status: :internal_server_error and return
   end
 
-  # PUT /nodes/:id/register_known_hosts
+  # PUT /nodes/:id/register_for_known_hosts
   def register_for_known_hosts
     ec2_instance = @infra.instance(@physical_id)
 

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -17,6 +17,7 @@ class NodesController < ApplicationController
   before_action :set_physical_id, only: %i[
     show get_security_groups submit_groups yum_update
     edit_ansible_playbook run_ansible_playbook update_ansible_playbook
+    register_for_known_hosts
   ]
 
   # infra
@@ -240,7 +241,11 @@ class NodesController < ApplicationController
 
   # PUT /nodes/:id/register_known_hosts
   def register_for_known_hosts
-    raise 'register_for_known_hosts not implemented!'
+    ec2_instance = @infra.instance(@physical_id)
+
+    ec2_instance.register_in_known_hosts(update: true)
+
+    render plain: I18n.t('nodes.msg.registered_in_known_hosts') and return
   end
 
   private

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -238,6 +238,11 @@ class NodesController < ApplicationController
     render plain: ret[:message], status: :internal_server_error and return
   end
 
+  # PUT /nodes/:id/register_known_hosts
+  def register_for_known_hosts
+    raise 'register_for_known_hosts not implemented!'
+  end
+
   private
 
   def update_playbook(physical_id: nil, infrastructure: nil, playbook_roles: nil, extra_vars: nil)

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -68,7 +68,6 @@ class ResourcesController < ApplicationController
         physical_id: physical_id,
         screen_name: screen_name,
         type_name: type_name,
-        register_in_known_hosts: true,
       )
     rescue StandardError => ex
       render plain: ex.message, status: :internal_server_error and return

--- a/app/libs/known_hosts.rb
+++ b/app/libs/known_hosts.rb
@@ -12,9 +12,9 @@ module KnownHosts
       true
     end
 
-    def scan_and_update_keys(domain_name)
-      delete_keys(domain_name)
-      scan_and_add_keys(domain_name)
+    def delete_keys(domain_name)
+      command = "ssh-keygen -R #{Shellwords.escape(domain_name)}"
+      exec_command(command)
     end
 
     def match_remote_key?(domain_name)
@@ -66,11 +66,6 @@ module KnownHosts
         file.puts(append_text)
         file.flock(File::LOCK_UN)
       end
-    end
-
-    def delete_keys(domain_name)
-      command = "ssh-keygen -R #{Shellwords.escape(domain_name)}"
-      exec_command(command)
     end
 
     def pub_key_part(known_host_line)

--- a/app/libs/known_hosts.rb
+++ b/app/libs/known_hosts.rb
@@ -22,23 +22,6 @@ module KnownHosts
       includes_keys_partial?(keys)
     end
 
-    def scan_keys(domain_name)
-      command = "ssh-keyscan #{Shellwords.escape(domain_name)}"
-      result = exec_command(command)
-      result.split("\n")
-    end
-
-    def add_keys(keys)
-      append_text = keys.map { |key| "#{key}\n" }.join
-
-      init_ssh_dir
-      File.open(known_hosts_path, mode: 'a') do |file|
-        file.flock(File::LOCK_EX)
-        file.puts(append_text)
-        file.flock(File::LOCK_UN)
-      end
-    end
-
     private
 
     def known_hosts_path
@@ -66,6 +49,23 @@ module KnownHosts
         end
       end
       false
+    end
+
+    def scan_keys(domain_name)
+      command = "ssh-keyscan #{Shellwords.escape(domain_name)}"
+      result = exec_command(command)
+      result.split("\n")
+    end
+
+    def add_keys(keys)
+      append_text = keys.map { |key| "#{key}\n" }.join
+
+      init_ssh_dir
+      File.open(known_hosts_path, mode: 'a') do |file|
+        file.flock(File::LOCK_EX)
+        file.puts(append_text)
+        file.flock(File::LOCK_UN)
+      end
     end
 
     def delete_keys(domain_name)

--- a/app/libs/known_hosts.rb
+++ b/app/libs/known_hosts.rb
@@ -19,7 +19,7 @@ module KnownHosts
 
     def match_remote_key?(domain_name)
       keys = scan_keys(domain_name)
-      includes_keys_partial?(keys)
+      includes_keys_partial?(domain_name, keys)
     end
 
     private
@@ -35,7 +35,7 @@ module KnownHosts
       File.open(known_hosts_path, mode: 'w', perm: 0o600).close unless File.exist?(known_hosts_path)
     end
 
-    def includes_keys_partial?(keys)
+    def includes_keys_partial?(domain_name, keys)
       raise ::ArgumentError, '"keys" is allow only Array' unless keys.is_a?(Array)
 
       pub_keys = keys.map do |known_host_line|
@@ -45,7 +45,7 @@ module KnownHosts
       init_ssh_dir
       File.open(known_hosts_path, mode: 'r') do |file|
         file.each_line do |line|
-          return true if pub_keys.any? { |pub_key| line.include?(pub_key) }
+          return true if pub_keys.any? { |pub_key| line.include?(domain_name) && line.include?(pub_key) }
         end
       end
       false

--- a/app/libs/known_hosts.rb
+++ b/app/libs/known_hosts.rb
@@ -12,6 +12,16 @@ module KnownHosts
       true
     end
 
+    def scan_and_update_keys(domain_name)
+      delete_keys(domain_name)
+      scan_and_add_keys(domain_name)
+    end
+
+    def match_remote_key?(domain_name)
+      keys = scan_keys(domain_name)
+      includes_keys_partial?(keys)
+    end
+
     def scan_keys(domain_name)
       command = "ssh-keyscan #{Shellwords.escape(domain_name)}"
       result = exec_command(command)
@@ -40,6 +50,32 @@ module KnownHosts
       Dir.mkdir(ssh_dir, 0o700) unless Dir.exist?(ssh_dir)
 
       File.open(known_hosts_path, mode: 'w', perm: 0o600).close unless File.exist?(known_hosts_path)
+    end
+
+    def includes_keys_partial?(keys)
+      raise ::ArgumentError, '"keys" is allow only Array' unless keys.is_a?(Array)
+
+      pub_keys = keys.map do |known_host_line|
+        pub_key_part(known_host_line)
+      end
+
+      init_ssh_dir
+      File.open(known_hosts_path, mode: 'r') do |file|
+        file.each_line do |line|
+          return true if pub_keys.any? { |pub_key| line.include?(pub_key) }
+        end
+      end
+      false
+    end
+
+    def delete_keys(domain_name)
+      command = "ssh-keygen -R #{Shellwords.escape(domain_name)}"
+      exec_command(command)
+    end
+
+    def pub_key_part(known_host_line)
+      # known_host_line example: domain_name_or_ip1,domain_name_or_ip2 ssh-rsa XXXXXXXXXX
+      known_host_line.split(nil).last
     end
 
     def exec_command(command)

--- a/app/models/ec2_instance.rb
+++ b/app/models/ec2_instance.rb
@@ -127,19 +127,17 @@ class EC2Instance < SimpleDelegator
       private_ip_address
   end
 
-  def register_in_known_hosts(tries: 1, sleep: 5, update: false)
+  def register_in_known_hosts
     fqdn_memo = fqdn
     raise RegisterNotSuccessError, 'failed to get fqdn' if fqdn_memo.blank?
 
     private_ip_address_memo = private_ip_address
     raise RegisterNotSuccessError, 'failed to get private_ip_address' if private_ip_address_memo.blank?
 
-    ::KnownHosts::delete_keys(fqdn_memo) if update
+    ::KnownHosts::delete_keys(fqdn_memo)
 
-    Retryable.retryable(tries: tries, on: RegisterNotSuccessError, sleep: sleep) do
-      registered = ::KnownHosts::scan_and_add_keys("#{fqdn_memo},#{private_ip_address_memo}")
-      raise RegisterNotSuccessError, 'failed to add keys in known_hosts' unless registered
-    end
+    registered = ::KnownHosts::scan_and_add_keys("#{fqdn_memo},#{private_ip_address_memo}")
+    raise RegisterNotSuccessError, 'failed to add keys in known_hosts' unless registered
   end
 
   def registered_in_known_hosts?

--- a/app/models/ec2_instance.rb
+++ b/app/models/ec2_instance.rb
@@ -153,6 +153,13 @@ class EC2Instance < SimpleDelegator
     end
   end
 
+  def registered_in_known_hosts?
+    fqdn_memo = fqdn
+    raise 'failed to get fqdn' if fqdn_memo.blank?
+
+    ::KnownHosts::match_remote_key?(fqdn_memo)
+  end
+
   def platform
     @instance.platform
   end

--- a/app/models/ec2_instance.rb
+++ b/app/models/ec2_instance.rb
@@ -39,19 +39,6 @@ class EC2Instance < SimpleDelegator
     end
   end
 
-  def wait_status_check_ok
-    loop do
-      s = status_check_info
-      if s[:instance_status] == 'ok' && s[:system_status] == 'ok'
-        break
-      end
-
-      raise StandardError, 'status check failed' unless %w[ok initializing].include?(s[:instance_status]) && %w[ok initializing].include?(s[:system_status])
-
-      sleep 5
-    end
-  end
-
   def status_check_info
     response = @infra.ec2.describe_instance_status(
       instance_ids: [physical_id],

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -87,7 +87,8 @@ class Resource < ApplicationRecord
   end
 
   def should_be_registered_in_known_hosts(msg)
-    raise NotRegisterInKnownHosts, msg unless register_in_known_hosts?
+    ec2_instance = infrastructure.instance(physical_id)
+    raise NotRegisterInKnownHosts, msg unless ec2_instance.registered_in_known_hosts?
   end
 
   private

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -145,17 +145,6 @@ class Stack
     end
   end
 
-  def wait_creat_complate_or_update_complete(interval = 10)
-    current_status = status[:status]
-    until %w[CREATE_COMPLETE UPDATE_COMPLETE].include?(current_status)
-      raise CreationError, "stack creation failed (#{current_status})" if failed?(current_status)
-
-      sleep interval
-      update_status
-      current_status = status[:status]
-    end
-  end
-
   # @param [String] logical_id is logical_resource_id. You defined in CloudFormation template.
   # @param [String] status_to_wait
   # @param [Integer] interval

--- a/app/policies/node_policy.rb
+++ b/app/policies/node_policy.rb
@@ -12,7 +12,7 @@ class NodePolicy < ApplicationPolicy
     user.allow?(record)
   end
 
-  %i[apply_dish? submit_groups? create_group? get_rules? get_security_groups? yum_update? schedule_yum? run_ansible_playbook? edit_ansible_playbook? update_ansible_playbook?].each do |action|
+  %i[register_for_known_hosts? apply_dish? submit_groups? create_group? get_rules? get_security_groups? yum_update? schedule_yum? run_ansible_playbook? edit_ansible_playbook? update_ansible_playbook?].each do |action|
     define_method(action) do
       user.admin? and user.allow?(record)
     end

--- a/app/views/infrastructures/modal/_modal_register_for_known_hosts.html.erb
+++ b/app/views/infrastructures/modal/_modal_register_for_known_hosts.html.erb
@@ -1,0 +1,27 @@
+<%# modal for register for known_hosts %>
+<div id="register-for-known-hosts-modal" class="modal" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <div class="modal-header bg-warning">
+        <button class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Register for known_hosts</h4>
+      </div>
+
+      <div class="modal-body">
+        <h4 class="alert alert-warning"><%= glyphicon 'warning-sign' %> Warning</h4>
+        <p>
+          <%= t('ec2_instances.msg.register_for_known_hosts') %>
+        </p>
+      </div>
+
+      <div class="modal-footer">
+        <div v-if="!loading_s">
+          <button class="btn btn-default" data-dismiss="modal" aria-hidden="true"><%= t('helpers.links.cancel') %></button>
+          <button @click="register_for_known_hosts()" data-dismiss="modal" class="btn btn-primary">OK</button>
+        </div>
+        <div-loader v-else-if="loading_s"></div-loader>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/vue/_ec2_tabpane.html.erb
+++ b/app/views/vue/_ec2_tabpane.html.erb
@@ -285,6 +285,9 @@
     <%# Buttons %>
     <div class="col-xs-12" v-if="!inprogress">
       <div class="form-actions-top">
+        <button href="#register-for-known-hosts-modal" role="button" class="btn btn-warning btn-sm" data-toggle="modal">
+          <%= t 'nodes.btn.register_for_known_hosts' %>
+        </button>
         <div :class="{'border-blink': ansible_status === 'UnExecuted'}" class="btn-group dropup">
           <button disabled class="btn btn-sm btn-primary">
             <%= t 'nodes.ansible' %>
@@ -471,4 +474,5 @@
 
   <%= render 'infrastructures/modal/modal_snapshot_retention_policy' %>
   <%= render 'infrastructures/modal/modal_create_volume' %>
+  <%= render 'infrastructures/modal/modal_register_for_known_hosts' %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,7 +344,7 @@ en:
       yum_update_success: |
         Yum update for <b> %{physical_id} </b> has been successful. <br>
         Do you want to see the logs for this operation?
-      not_register_in_known_hosts: There is no key registered in known_hosts. Please try again later.
+      not_register_in_known_hosts: There is no key registered in known_hosts.
 
   dishes:
     dishes:            'Dishes'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,7 +346,7 @@ en:
       yum_update_success: |
         Yum update for <b> %{physical_id} </b> has been successful. <br>
         Do you want to see the logs for this operation?
-      not_register_in_known_hosts: Key is not registered, or not match remote host key, in known_hosts.
+      not_register_in_known_hosts: Key is not registered, or not match remote host key, in known_hosts.(Processing is not started)
 
   dishes:
     dishes:            'Dishes'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,6 +318,7 @@ en:
     latest_serverspec_status: 'Latest Serverspec Status'
     cook_in_why_run_mode:     'Cook(why-run)'
     btn:
+      register_for_known_hosts: 'Register for known_hosts'
       edit_playbook:    'Edit playbook'
       apply_dish:                 'Apply Dish'
       bootstrap_with_chef_server: 'Bootstrap with Chef Server'
@@ -667,6 +668,9 @@ en:
       detach_volume:         'Are you sure you want to detach %{volume_id} from %{physical_id}?'
       volume_detached:       '%{volume_id} has detached.'
       creating_volume:       'Creating volume <code>%{volume_id}</code> has started.'
+      register_for_known_hosts: |
+        Register remote server key for known_hosts.
+        If known_hosts registered key already, register after remove.
     btn:
       register:   'Register to ELB'
       deregister: 'Deregister from ELB'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,7 +344,7 @@ en:
       yum_update_success: |
         Yum update for <b> %{physical_id} </b> has been successful. <br>
         Do you want to see the logs for this operation?
-      not_register_in_known_hosts: There is no key registered in known_hosts.
+      not_register_in_known_hosts: Key is not registered, or not match remote host key, in known_hosts.
 
   dishes:
     dishes:            'Dishes'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,7 @@ en:
       yum_update_started: 'yum command is started.'
       attr_not_exists:    'Available attributes does not exists'
       playbook_empty:     'playbook is empty'
+      registered_in_known_hosts: 'Key was registered for known_hosts'
       dish_applied:       'Dish was applied.'
       stopped:            'Instance has stopped. Please start instance to enable bootstrap.'
       yum_update_success: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -670,7 +670,7 @@ en:
       creating_volume:       'Creating volume <code>%{volume_id}</code> has started.'
       register_for_known_hosts: |
         Register remote server key for known_hosts.
-        If known_hosts registered key already, register after remove.
+        In case the key is already registered in known_hosts, register the new key after deleting the existing.
     btn:
       register:   'Register to ELB'
       deregister: 'Deregister from ELB'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -343,7 +343,7 @@ ja:
       yum_update_success: |
           %{physical_id}のYumアップデートが成功しました。 <br>
           この操作のログを表示しますか？
-      not_register_in_known_hosts: 'known_hostsに鍵が登録されていない、もしくはリモートホストの鍵と一致しません'
+      not_register_in_known_hosts: 'known_hostsに鍵が登録されていない、もしくはリモートホストの鍵と一致しません（処理は開始されていません）'
 
 
   dishes:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -341,7 +341,7 @@ ja:
       yum_update_success: |
           %{physical_id}のYumアップデートが成功しました。 <br>
           この操作のログを表示しますか？
-      not_register_in_known_hosts: known_hostsに鍵が登録されていません。しばらくしてから再度お試しください。
+      not_register_in_known_hosts: 'known_hostsに鍵が登録されていません'
 
 
   dishes:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -341,7 +341,7 @@ ja:
       yum_update_success: |
           %{physical_id}のYumアップデートが成功しました。 <br>
           この操作のログを表示しますか？
-      not_register_in_known_hosts: 'known_hostsに鍵が登録されていません'
+      not_register_in_known_hosts: 'known_hostsに鍵が登録されていない、もしくはリモートホストの鍵と一致しません'
 
 
   dishes:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -315,6 +315,7 @@ ja:
     latest_serverspec_status: 'Serverspec'
     cook_in_why_run_mode:     'Cook(why-run)'
     btn:
+      register_for_known_hosts:   'known_hostsに登録'
       edit_playbook:              'playbook の編集'
       apply_dish:                 'ディッシュの適用'
       bootstrap_with_chef_server: 'Chef Server に登録'
@@ -664,6 +665,9 @@ ja:
       detach_volume:         '%{physical_id} から %{volume_id} をデタッチします。本当によろしいですか?'
       volume_detached:       '%{volume_id} をデタッチ中です...'
       creating_volume:       'ボリューム <code>%{volume_id}</code> の作成が開始されました'
+      register_for_known_hosts: |
+        known_hostsにリモートサーバの鍵を登録します。
+        既にknown_hostsに鍵が登録されている場合は、削除した後に登録します。
     btn:
       register:   'インスタンスを登録'
       deregister: 'インスタンスの登録を解除'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -337,6 +337,7 @@ ja:
       yum_update_started: 'yum が正常に開始されました'
       attr_not_exists:    '利用可能なアトリビュートは存在しません'
       playbook_empty:     'playbook は空です'
+      registered_in_known_hosts: 'known_hostsに鍵が登録されました'
       dish_applied:       'Dish が適用されました'
       stopped:            'インスタンスが停止しています。ブートストラップを可能にするには、インスタンスを起動してください。'
       yum_update_success: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ SkyHopper::Application.routes.draw do
       post 'create_group'
     end
     member do
+      post 'register_for_known_hosts'
       put  'yum_update'
       post 'apply_dish'
       post 'submit_groups'

--- a/db/migrate/20191108072820_remove_register_in_known_hosts_to_resource.rb
+++ b/db/migrate/20191108072820_remove_register_in_known_hosts_to_resource.rb
@@ -1,0 +1,5 @@
+class RemoveRegisterInKnownHostsToResource < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :resources, :register_in_known_hosts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_01_021016) do
+ActiveRecord::Schema.define(version: 2019_11_08_072820) do
 
   create_table "app_settings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "aws_region", null: false
@@ -170,7 +170,6 @@ ActiveRecord::Schema.define(version: 2019_10_01_021016) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "screen_name"
-    t.boolean "register_in_known_hosts"
     t.integer "dish_id"
     t.text "playbook_roles"
     t.text "extra_vars"

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -9,7 +9,7 @@ $ cd <project-root>
 $ cp config/database_docker.yml config/database.yml
 $ cp docker-compose.override-sample.yml docker-compose.override.yml
 $ # ここでconfig/database.ymlとdocker-compose.override.ymlのmysqlのパスワードを変更してください
-$ touch amazonlinux2/known_hosts
+$ touch amazonlinux2/.ssh/known_hosts
 $ chmod 644 amazonlinux2/known_hosts
 $ docker-compose build
 $ # ここで後述する「フォントのダウンロードとビルド」を行ってください

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: ./Dockerfile
     volumes:
       - ".:/prj/skyhopper"
-      - "./amazonlinux2/known_hosts:/root/.ssh/known_hosts"
+      - "./amazonlinux2/.ssh:/root/.ssh"
       # exclude
       - /prj/skyhopper/.git
     environment:

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -74,10 +74,10 @@ describe NodesController, type: :controller do
     let(:resource) { create(:resource, infrastructure: infra) }
     let(:req) { post :register_for_known_hosts, params: { id: resource.physical_id, infra_id: infra.id } }
 
-    before {
+    before do
       allow_any_instance_of(EC2Instance).to receive(:register_in_known_hosts)
       req
-    }
+    end
 
     should_be_success
 

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -70,6 +70,22 @@ describe NodesController, type: :controller do
     end
   end
 
+  describe '#register_for_known_hosts' do
+    let(:resource) { create(:resource, infrastructure: infra) }
+    let(:req) { post :register_for_known_hosts, params: { id: resource.physical_id, infra_id: infra.id } }
+
+    before {
+      allow_any_instance_of(EC2Instance).to receive(:register_in_known_hosts)
+      req
+    }
+
+    should_be_success
+
+    it 'should render message' do
+      expect(response.body).to eq I18n.t('nodes.msg.registered_in_known_hosts')
+    end
+  end
+
   describe '#apply_dish' do
     let(:resource) { create(:resource, infrastructure: infra) }
     let(:req) { post :apply_dish, params: { id: resource.physical_id, infra_id: infra.id, dish_id: dish.id } }
@@ -110,6 +126,7 @@ describe NodesController, type: :controller do
     let(:req) { put :yum_update, params: { id: resource.physical_id, infra_id: resource.infrastructure.id, security: security, exec: exec } }
 
     before do
+      allow_any_instance_of(EC2Instance).to receive(:registered_in_known_hosts?).and_return(true)
       allow_any_instance_of(NodesController).to receive(:exec_yum_update)
         .with(resource.infrastructure, resource.physical_id, security == 'security', exec == 'exec')
       req
@@ -184,6 +201,7 @@ describe NodesController, type: :controller do
     let(:run_ansible_playbook_request) { put :run_ansible_playbook, params: { id: resource.physical_id, infra_id: resource.infrastructure.id } }
 
     before do
+      allow_any_instance_of(EC2Instance).to receive(:registered_in_known_hosts?).and_return(true)
       allow(Thread).to receive(:new_with_db).and_yield
       expect_any_instance_of(NodesController).to receive(:run_ansible_playbook_node)
       run_ansible_playbook_request

--- a/spec/controllers/servertests_controller_spec.rb
+++ b/spec/controllers/servertests_controller_spec.rb
@@ -307,6 +307,7 @@ describe ServertestsController, type: :controller do
 
     before do
       resource
+      allow_any_instance_of(EC2Instance).to receive(:registered_in_known_hosts?).and_return(true)
       allow(ServertestJob).to receive(:perform_now).and_return(resp)
     end
 

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -13,19 +13,16 @@ FactoryGirl.define do
     sequence(:physical_id) { |n| "i-123#{n}abc" }
     type_name 'AWS::EC2::Instance'
     screen_name 'EC2 Instance'
-    register_in_known_hosts true
     infrastructure
 
     factory :rds_resource do
       type_name   'AWS::RDS::DBInstance'
       screen_name nil
-      register_in_known_hosts nil
     end
 
     factory :s3bucket_resource do
       type_name   'AWS::S3::Bucket'
       screen_name nil
-      register_in_known_hosts nil
     end
   end
 end

--- a/spec/policies/node_policy_spec.rb
+++ b/spec/policies/node_policy_spec.rb
@@ -43,7 +43,7 @@ describe NodePolicy do
     end
   end
 
-  %i[apply_dish? yum_update? run_ansible_playbook? edit_ansible_playbook? update_ansible_playbook?].each do |action|
+  %i[register_for_known_hosts? apply_dish? yum_update? run_ansible_playbook? edit_ansible_playbook? update_ansible_playbook?].each do |action|
     permissions action do
       context 'when allowed user' do
         before do


### PR DESCRIPTION
@@@ NOTICE @@@
known_hostsをハッシュ化している環境では、このアップデートを適用すると正常に動作しなくなる可能性があります。
現時点でSkyHopperがサポートしているAmazonLinux(ver1)での動作は確認致しました。
@@@@@@@@@@

known_hostsにEC2の鍵を登録するボタンを追加しました。
Ansible、yum、Servertest実行時に、known_hostsにリモートホストの鍵が登録されているか確認する処理を、"DBのフラグで確認"から"実際に取得して確認"に変更しました。
CloudFormationテンプレート展開完了時に、known_hostsに鍵を登録する処理を削除しました。

Dockerを使用している場合は、下記のコマンドを実行する必要があります。
```
mv amazonlinux2/known_hosts amazonlinux2/.ssh/
```